### PR TITLE
Feature Request - Team Access and Statefile Sharing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Added**
 
+* `tfx workspace team list` - List team access information for the Workspace.
+
 **Changed**
 
 **Removed**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Added**
 
-* `tfx workspace team list` - List team access information for the Workspace.
+* `tfx workspace team list` - List team access information for a given Workspace.
 
 **Changed**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Changed**
 
+* `tfx workspace show` - Now includes Team Access and Statefile Sharing output for the Workspace.
+
 **Removed**
 
 ## [0.1.0] - 2022.08.21

--- a/cmd/workspace.go
+++ b/cmd/workspace.go
@@ -267,7 +267,7 @@ func workspaceShow(c TfxClientContext, workspaceName string) error {
 		return errors.Wrap(err, "failed to list remote state consumers")
 	}
 
-	ta, err := workspaceTeamListAll(c, w.ID, math.MaxInt)
+	ta, err := workspaceListAllTeams(c, w.ID, math.MaxInt)
 	if err != nil {
 		return errors.Wrap(err, "failed to list teams")
 	}

--- a/cmd/workspace_team.go
+++ b/cmd/workspace_team.go
@@ -1,0 +1,113 @@
+// Copyright © 2021 Tom Straub <github.com/straubt1>
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+package cmd
+
+import (
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+var (
+	// `tfx workspace team` commands
+	workspaceTeamCmd = &cobra.Command{
+		Use:   "team",
+		Short: "Team Commands",
+		Long:  "Commands to work with Workspace Teams.",
+	}
+
+	// `tfx workspace team list` command
+	workspaceTeamListCmd = &cobra.Command{
+		Use:   "list",
+		Short: "List Teams",
+		Long:  "List Teams in a Workspace.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return workspaceTeamList(
+				getTfxClientContext(),
+				*viperString("workspace-name"))
+		},
+	}
+)
+
+func init() {
+	// `tfx variable list` command
+	workspaceTeamListCmd.Flags().StringP("workspace-name", "w", "", "Name of the Workspace")
+	workspaceTeamListCmd.MarkFlagRequired("workspace-name")
+
+	workspaceCmd.AddCommand(workspaceTeamCmd)
+	workspaceTeamCmd.AddCommand(workspaceTeamListCmd)
+}
+
+func workspaceTeamListAll(c TfxClientContext, workspaceId string, maxItems int) ([]*tfe.TeamAccess, error) {
+	pageSize := 100
+	if maxItems < 100 {
+		pageSize = maxItems // Only get what we need in one page
+	}
+
+	allItems := []*tfe.TeamAccess{}
+	opts := tfe.TeamAccessListOptions{
+		ListOptions: tfe.ListOptions{PageNumber: 1, PageSize: pageSize},
+		WorkspaceID: workspaceId,
+	}
+	for {
+		items, err := c.Client.TeamAccess.List(c.Context, &opts)
+		if err != nil {
+			return nil, err
+		}
+
+		allItems = append(allItems, items.Items...)
+		if len(allItems) >= maxItems {
+			break // Hit the max, break. For maxItems > 100 it is possible to return more than max in this approach
+		}
+
+		if items.CurrentPage >= items.TotalPages {
+			break
+		}
+		opts.PageNumber = items.NextPage
+	}
+
+	return allItems, nil
+}
+
+func workspaceTeamList(c TfxClientContext, workspaceName string) error {
+	o.AddMessageUserProvided("List Variables for Workspace:", workspaceName)
+	workspaceId, err := getWorkspaceId(c, workspaceName)
+	if err != nil {
+		return errors.Wrap(err, "unable to read workspace id")
+	}
+
+	items, err := workspaceTeamListAll(c, workspaceId, 1000) //TODO: max items
+	if err != nil {
+		return errors.Wrap(err, "failed to list teams")
+	}
+
+	o.AddTableHeader("Name", "Team Id", "Team Access Id", "Access Type", "Run Perms", "Sentinel Perms", "Run Task", "Variables", "State Versions")
+	for _, i := range items {
+
+		t, err := c.Client.Teams.Read(c.Context, i.Team.ID)
+		if err != nil {
+			return errors.Wrap(err, "failed to find team name")
+		}
+
+		o.AddTableRows(t.Name, i.Team.ID, i.ID, i.Access, i.Runs, i.SentinelMocks, i.RunTasks, i.Variables, i.StateVersions)
+	}
+
+	return nil
+}

--- a/cmd/workspace_team.go
+++ b/cmd/workspace_team.go
@@ -65,7 +65,7 @@ func init() {
 	workspaceTeamCmd.AddCommand(workspaceTeamListCmd)
 }
 
-func workspaceTeamListAll(c TfxClientContext, workspaceId string, maxItems int) ([]*tfe.TeamAccess, error) {
+func workspaceListAllTeams(c TfxClientContext, workspaceId string, maxItems int) ([]*tfe.TeamAccess, error) {
 	pageSize := 100
 	if maxItems < 100 {
 		pageSize = maxItems // Only get what we need in one page
@@ -103,7 +103,7 @@ func workspaceTeamList(c TfxClientContext, workspaceName string, maxItems int) e
 		return errors.Wrap(err, "unable to read workspace id")
 	}
 
-	items, err := workspaceTeamListAll(c, workspaceId, maxItems)
+	items, err := workspaceListAllTeams(c, workspaceId, maxItems)
 	if err != nil {
 		return errors.Wrap(err, "failed to list teams")
 	}

--- a/site/docs/commands/workspace.md
+++ b/site/docs/commands/workspace.md
@@ -68,7 +68,7 @@ Found 141 Workspaces
 
 ## `tfx workspace show`
 
-Show details of a given Workspace, include Team Access.
+Show details of a given Workspace, include Team Access and State sharing.
 
 **Example**
 

--- a/site/docs/commands/workspace.md
+++ b/site/docs/commands/workspace.md
@@ -76,14 +76,16 @@ Show details of a given Workspace, include Team Access.
 $ tfx workspace show -n tfx-test
 Using config file: /Users/tstraub/.tfx.hcl
 Show Workspace: tfx-test
-ID:                  ws-VxepewkunumUbR9V
-Terraform Version:   1.0.0
-Execution Mode:      remote
-Auto Apply:          false
-Working Directory:   
-Locked:              false
-Current Run Id:      run-muJzD4EXcYXeb6aY
-Current Run Status:  planned_and_finished
-Current Run Created: Sat Aug 20 14:45 2022
-Team Access:         appteam-read,appteam-custom
+ID:                   ws-VxepewkunumUbR9V
+Terraform Version:    1.0.0
+Execution Mode:       remote
+Auto Apply:           false
+Working Directory:    
+Locked:               false
+Global State Sharing: false
+Current Run Id:       run-muJzD4EXcYXeb6aY
+Current Run Status:   planned_and_finished
+Current Run Created:  Sat Aug 20 14:45 2022
+Team Access:          appteam-read,appteam-custom
+Remote State Sharing: tfx-test-workspace-16,tfx-test-workspace-17
 ```

--- a/site/docs/commands/workspace.md
+++ b/site/docs/commands/workspace.md
@@ -68,7 +68,7 @@ Found 141 Workspaces
 
 ## `tfx workspace show`
 
-Show details of a given Workspace.
+Show details of a given Workspace, include Team Access.
 
 **Example**
 
@@ -85,4 +85,5 @@ Locked:              false
 Current Run Id:      run-muJzD4EXcYXeb6aY
 Current Run Status:  planned_and_finished
 Current Run Created: Sat Aug 20 14:45 2022
+Team Access:         appteam-read,appteam-custom
 ```

--- a/site/docs/commands/workspace_team.md
+++ b/site/docs/commands/workspace_team.md
@@ -1,0 +1,24 @@
+# Workspace Commands
+
+General commands to manage Workspace Team Access.
+
+!!! note ""
+    All commands below can be used with a `ws` alias.
+
+## `tfx workspace team list`
+
+List Team Access for a supplied Workspace, including the permissions.
+
+**Example**
+
+```sh
+$ tfx workspace team list -w tfx-test          
+Using config file: /Users/tstraub/.tfx.hcl
+List Variables for Workspace: tfx-test
+╭───────────────┬───────────────────────┬──────────────────────┬─────────────┬───────┬───────────────────┬────────────────┬───────────┬───────────┬────────────────╮
+│ NAME          │ TEAM ID               │ TEAM ACCESS ID       │ ACCESS TYPE │ RUNS  │ WORKSPACE LOCKING │ SENTINEL MOCKS │ RUN TASKS │ VARIABLES │ STATE VERSIONS │
+├───────────────┼───────────────────────┼──────────────────────┼─────────────┼───────┼───────────────────┼────────────────┼───────────┼───────────┼────────────────┤
+│ appteam-write │ team-phMhWZUz3Hkog8Qp │ tws-LfZNEXKvxfpS5W7a │ write       │ apply │ true              │ read           │ false     │ write     │ write          │
+│ appteam-cust  │ team-f5hT25igBATWry5u │ tws-qApZtrp4KEjDjqBq │ custom      │ read  │ true              │ read           │ false     │ none      │ none           │
+╰───────────────┴───────────────────────┴──────────────────────┴─────────────┴───────┴───────────────────┴────────────────┴───────────┴───────────┴────────────────╯
+```

--- a/site/mkdocs.yml
+++ b/site/mkdocs.yml
@@ -52,6 +52,7 @@ nav:
       - Variables: commands/workspace_variable.md
       - Runs: commands/workspace_run.md
       - Lock: commands/workspace_lock.md
+      - Team: commands/workspace_team.md
       - Configuration Versions: commands/workspace_configurationversion.md
       - State Versions: commands/workspace_stateversion.md
     - Private Registry:


### PR DESCRIPTION
Fixes #29
Fixed #30 

## Proposed Changes

  - Adds Team Access as a subcommand for a `tfx workspace` (also adds Global State Sharing to the output)
```
$ tfx workspace team list -w tfx-test        
Using config file: /Users/tstraub/.tfx.hcl
List Variables for Workspace: tfx-test
╭──────────────┬───────────────────────┬──────────────────────┬─────────────┬───────┬───────────────────┬────────────────┬───────────┬───────────┬────────────────╮
│ NAME         │ TEAM ID               │ TEAM ACCESS ID       │ ACCESS TYPE │ RUNS  │ WORKSPACE LOCKING │ SENTINEL MOCKS │ RUN TASKS │ VARIABLES │ STATE VERSIONS │
├──────────────┼───────────────────────┼──────────────────────┼─────────────┼───────┼───────────────────┼────────────────┼───────────┼───────────┼────────────────┤
│ appteam-read │ team-phMhWZUz3Hkog8Qp │ tws-LfZNEXKvxfpS5W7a │ write       │ apply │ true              │ read           │ false     │ write     │ write          │
│ ws-outputs   │ team-f5hT25igBATWry5u │ tws-qApZtrp4KEjDjqBq │ custom      │ read  │ true              │ read           │ false     │ none      │ none           │
╰──────────────┴───────────────────────┴──────────────────────┴─────────────┴───────┴───────────────────┴────────────────┴───────────┴───────────┴────────────────╯
```

  - Adds Team Access and Statefile Sharing to the `tfx workspace show` Command
```
$ tfx workspace show -n tfx-test   
Using config file: /Users/tstraub/.tfx.hcl
Show Workspace: tfx-test
ID:                  ws-VxepewkunumUbR9V
Terraform Version:   1.0.0
Execution Mode:      remote
Auto Apply:          false
Working Directory:   
Locked:              false
Global State Sharing: false
Current Run Id:      run-tNGxao7zMos5YrY1
Current Run Status:  errored
Current Run Created: Sun Aug 21 16:40 2022
Team Access:         appteam-read,ws-outputs
Remote State Sharing: tfx-test-workspace-16,tfx-test-workspace-17
```

