### PR TITLE
Update ouput to handle Lists and Maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Changed**
 
-* Updated `tfx workspace list` to add a flag `--respository` that will filter based on workspaces that are connected to the specified repository identifier.
+* Updated `tfx workspace list` to add a flag `--repository` that will filter based on workspaces that are connected to the specified repository identifier.
 
 * `tfx workspace show` - Now includes Team Access and Statefile Sharing output for the Workspace.
 

--- a/cmd/workspace.go
+++ b/cmd/workspace.go
@@ -332,13 +332,9 @@ func workspaceShow(c TfxClientContext, workspaceName string) error {
 	// if there are any Team Assignments,
 	// loop through team access and get team names (requires an additional API call)
 	if len(ta) > 0 {
-		var teamNames []interface{}
-		for _, i := range ta {
-			t, err := c.Client.Teams.Read(c.Context, i.Team.ID)
-			if err != nil {
-				return errors.Wrap(err, "failed to find team name")
-			}
-			teamNames = append(teamNames, t.Name)
+		teamNames, err := getTeamAccessNames(c, ta)
+		if err != nil {
+			return errors.Wrap(err, "failed to find team name")
 		}
 		o.AddDeferredListMessageRead("Team Access", teamNames)
 	}

--- a/cmd/workspace.go
+++ b/cmd/workspace.go
@@ -23,7 +23,6 @@ package cmd
 
 import (
 	"math"
-	"strings"
 
 	"github.com/hashicorp/go-tfe"
 	"github.com/pkg/errors"
@@ -333,7 +332,7 @@ func workspaceShow(c TfxClientContext, workspaceName string) error {
 	// if there are any Team Assignments,
 	// loop through team access and get team names (requires an additional API call)
 	if len(ta) > 0 {
-		teamNames := []string{}
+		var teamNames []interface{}
 		for _, i := range ta {
 			t, err := c.Client.Teams.Read(c.Context, i.Team.ID)
 			if err != nil {
@@ -341,17 +340,17 @@ func workspaceShow(c TfxClientContext, workspaceName string) error {
 			}
 			teamNames = append(teamNames, t.Name)
 		}
-		o.AddDeferredMessageRead("Team Access", strings.Join(teamNames, ","))
+		o.AddDeferredListMessageRead("Team Access", teamNames)
 	}
 
 	// if there are any Statefile Sharing with workspaces,
 	// loop through workspace and get names
 	if len(rsc) > 0 {
-		wsNames := []string{}
+		var wsNames []interface{}
 		for _, i := range rsc {
 			wsNames = append(wsNames, i.Name)
 		}
-		o.AddDeferredMessageRead("Remote State Sharing", strings.Join(wsNames, ","))
+		o.AddDeferredListMessageRead("Remote State Sharing", wsNames)
 	}
 
 	return nil

--- a/cmd/workspace_run.go
+++ b/cmd/workspace_run.go
@@ -225,17 +225,23 @@ func runShow(c TfxClientContext, runId string) error {
 
 	}
 	// test := []interface{"a", "b"}
-	var test []interface{}
-	test = append(test, "a")
-	test = append(test, "b")
-	o.AddDeferredListMessageRead("Policy Checks", test)
+	test := []interface{}{
+		"ws-1",
+		"ws-2",
+		"ws-3",
+	}
+	o.AddDeferredListMessageRead("workspaces", test)
 
-	var testComplex [][]interface{}
-	testComplex = append(testComplex, test)
-	o.AddDeferredListComplexMessageRead("Complex", testComplex)
+	testComplex := map[string]interface{}{
+		"policy-a": "passed",
+		"policy-b": true,
+		"policy-c": 4,
+	}
+	// testComplex = append(testComplex, test)
+	o.AddDeferredMapMessageRead("Policy Checks", testComplex)
 
-	o.AddDeferredMessageRead("Policy Checks Passed", policyPassed)
-	o.AddDeferredMessageRead("Policy Checks Failed", policyFailed)
+	// o.AddDeferredMessageRead("Policy Checks Passed", policyPassed)
+	// o.AddDeferredMessageRead("Policy Checks Failed", policyFailed)
 
 	return nil
 }

--- a/cmd/workspace_run.go
+++ b/cmd/workspace_run.go
@@ -201,47 +201,12 @@ func runShow(c TfxClientContext, runId string) error {
 		return errors.Wrap(err, "failed to read run from id")
 	}
 
-	pc, err := c.Client.PolicyChecks.List(c.Context, run.ID, &tfe.PolicyCheckListOptions{ // TODO add paging
-		ListOptions: tfe.ListOptions{},
-		Include:     []tfe.PolicyCheckIncludeOpt{},
-	})
-	if err != nil {
-		return errors.Wrap(err, "failed to read policy checks")
-	}
-
 	o.AddDeferredMessageRead("ID", run.ID)
 	o.AddDeferredMessageRead("Configuration Version", run.ConfigurationVersion.ID)
 	o.AddDeferredMessageRead("Status", run.Status)
 	o.AddDeferredMessageRead("Message", run.Message)
 	o.AddDeferredMessageRead("Terraform Version", run.TerraformVersion)
 	o.AddDeferredMessageRead("Created", FormatDateTime(run.CreatedAt))
-
-	policyPassed, policyFailed := 0, 0
-	for _, i := range pc.Items {
-		// each item will be from a policy set
-		// but each has it's own set of policy checks
-		policyPassed += i.Result.Passed
-		policyFailed += i.Result.TotalFailed
-
-	}
-	// test := []interface{"a", "b"}
-	test := []interface{}{
-		"ws-1",
-		"ws-2",
-		"ws-3",
-	}
-	o.AddDeferredListMessageRead("workspaces", test)
-
-	testComplex := map[string]interface{}{
-		"policy-a": "passed",
-		"policy-b": true,
-		"policy-c": 4,
-	}
-	// testComplex = append(testComplex, test)
-	o.AddDeferredMapMessageRead("Policy Checks", testComplex)
-
-	// o.AddDeferredMessageRead("Policy Checks Passed", policyPassed)
-	// o.AddDeferredMessageRead("Policy Checks Failed", policyFailed)
 
 	return nil
 }

--- a/cmd/workspace_team.go
+++ b/cmd/workspace_team.go
@@ -119,3 +119,16 @@ func workspaceTeamList(c TfxClientContext, workspaceName string, maxItems int) e
 
 	return nil
 }
+
+func getTeamAccessNames(c TfxClientContext, ta []*tfe.TeamAccess) ([]interface{}, error) {
+	var teamNames []interface{}
+	for _, i := range ta {
+		t, err := c.Client.Teams.Read(c.Context, i.Team.ID)
+		if err != nil {
+			return nil, err
+		}
+		teamNames = append(teamNames, t.Name)
+	}
+
+	return teamNames, nil
+}

--- a/output/writer.go
+++ b/output/writer.go
@@ -129,8 +129,8 @@ func (o Output) closeMessagesDefault() {
 
 			// determine spacing based on largest key in map (left justify)
 			maxLengthMap := 0
-			for k, _ := range k.ValueMap {
-				if len(k) > maxLength {
+			for k := range k.ValueMap {
+				if len(k) > maxLengthMap {
 					maxLengthMap = len(k)
 				}
 			}

--- a/site/docs/about/style_guide.md
+++ b/site/docs/about/style_guide.md
@@ -18,6 +18,44 @@ The goal of this document is to outline the general user experience when dealing
 - Error: Red
     - It is the way Rick Sanchez would want it...
 
+## Output Spacing
+
+For all outputs where the Value (in the Key/Value message) is a primitive, the Key will be left justified, the Value will be spaced to be even with other messages returned by the command.
+
+Example:
+
+```
+ID:                   ws-VxepewkunumUbR9V
+Terraform Version:    1.0.0
+Execution Mode:       remote
+Locked:               false
+Global State Sharing: false
+Current Run Id:       run-tNGxao7zMos5YrY1
+```
+
+For outputs where the Value is a List, the Key will be left justified, the Values of the List will be on a new line with a two space left-padding.
+
+Example:
+
+```
+Some List:           
+  item1
+  item2
+  item3
+```
+
+For outputs where the Value is a Map, the Key will be left justified, the Values of the Map will be on a new line with a two space left-padding for the inner key and be spaced to be even with other inner keys in the message.
+
+Example:
+
+```
+Some Map:            
+  item3:           5
+  item4Long:       5.3
+  item1:           string_value 1
+  item2ReallyLong: true
+```
+
 ## Command and Flag Naming
 
 Command and Flag naming will adhere to the following standards:

--- a/site/docs/commands/workspace.md
+++ b/site/docs/commands/workspace.md
@@ -114,7 +114,7 @@ Show details of a given Workspace, include Team Access and State sharing.
 **Example**
 
 ```sh
-$ tfx workspace show -n tfx-test
+$ tfx workspace show -n tfx-test          
 Using config file: /Users/tstraub/.tfx.hcl
 Show Workspace: tfx-test
 ID:                   ws-VxepewkunumUbR9V
@@ -124,9 +124,13 @@ Auto Apply:           false
 Working Directory:    
 Locked:               false
 Global State Sharing: false
-Current Run Id:       run-muJzD4EXcYXeb6aY
-Current Run Status:   planned_and_finished
-Current Run Created:  Sat Aug 20 14:45 2022
-Team Access:          appteam-read,appteam-custom
-Remote State Sharing: tfx-test-workspace-16,tfx-test-workspace-17
+Current Run Id:       run-tNGxao7zMos5YrY1
+Current Run Status:   errored
+Current Run Created:  Sun Aug 21 16:40 2022
+Team Access:         
+  appteam-read
+  ws-outputs
+Remote State Sharing:
+  tfx-test-workspace-16
+  tfx-test-workspace-17
 ```


### PR DESCRIPTION
## Proposed Changes

Before this change all output had to be key/value to handle the `--json` output type.
This introduces the ability to add more complex output for easier visualization and JSON parsing.

**List Example**

```
typeList := []interface{}{
  "item1",
  "item2",
  "item3",
}
o.AddDeferredListMessageRead("Some List", typeList)
```

Would output, starting each line of the list items with 2 spaces:
```
Some List:           
  item1
  item2
  item3
```


**Map Example**

```
typeMap := map[string]interface{}{
  "item1": "string_value 1",
  "item2": true,
  "item3": 5,
  "item4": 5.3,
}
o.AddDeferredMapMessageRead("Some Map", typeMap)
```

Would output, starting each line of the map items with 2 spaces:
```
Some Map:            
  item1: string_value 1
  item2: true
  item3: 5
  item4: 5.3
```

Color coded:
![image](https://user-images.githubusercontent.com/8408833/189545770-3d221c48-9d1f-46d4-bd33-6aeecbc8097c.png)
