### PR TITLE
feat(ci): use goreleaser for binary and container builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,87 +1,49 @@
-name: Release `tfx`
+name: goreleaser
 
 on:
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+  packages: write
 
 jobs:
-  build:
+  goreleaser:
     runs-on: ubuntu-latest
+    env:
+      DOCKER_CLI_EXPERIMENTAL: "enabled"
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
+      -
+        name: Checkout
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
-      # - name: Lint
-      #   uses: golangci/golangci-lint-action@v2
-      #   with:
-      #     version: v1.32.2
-
-      - name: Make tag
-        run: echo "TAG_NAME=${GITHUB_REF##*/}" >> $GITHUB_ENV
-
-      - name: Get release
-        id: get_release
-        uses: bruceadams/get-release@v1.2.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Install Go
-        uses: actions/setup-go@v2
+      -
+        name: Set up Go
+        uses: actions/setup-go@v3
         with:
-          go-version: 1.21.0
-      - name: Install gox
-        run: |
-          go get github.com/mitchellh/gox 
-          go install github.com/mitchellh/gox 
-        
-      - name: Cross compile
-        run: |
-          gox \
-            -os="linux darwin windows" \
-            -ldflags="-X 'github.com/straubt1/tfx/version.BuiltBy=github'" \
-            -arch="amd64 arm64" \
-            -output "./pkg/{{.OS}}_{{.Arch}}/tfx" \
-            .
-      - name: Print version
-        run: ./pkg/linux_amd64/tfx --version
+          go-version: 1.19
+      -
+        name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
 
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: ghcr-login
+        uses: docker/login-action@v2
         with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: ./pkg/darwin_amd64/tfx
-          asset_name: tfx_darwin_amd64
-          asset_content_type: application/octet-stream
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v3
         with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: ./pkg/darwin_arm64/tfx
-          asset_name: tfx_darwin_arm64
-          asset_content_type: application/octet-stream
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1.0.2
+          version: latest
+          args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: ./pkg/linux_amd64/tfx
-          asset_name: tfx_linux_amd64
-          asset_content_type: application/octet-stream
-      - name: Upload Release Asset
-        uses: actions/upload-release-asset@v1.0.2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: ./pkg/windows_amd64/tfx.exe
-          asset_name: tfx_windows_amd64
-          asset_content_type: application/octet-stream
-
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,120 @@
+env:
+  - GO111MODULE=on
+  - CGO_ENABLED=0
+
+builds:
+  -
+    binary: tfx
+    ldflags: -s -w -X version.Version={{ .Version }}
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+      
+archives:
+  -
+    builds:
+      - tfx
+    format_overrides:
+      - goos: windows
+        format: zip
+    name_template: >-
+      {{- .ProjectName }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end -}}
+
+nfpms:
+  - builds:
+      - tfx
+    vendor: straubt1
+    homepage:  https://tfx.rocks/
+    maintainer: "Tom Straub <straub@hashicorp.com>"
+    description: "TFx is a standalone CLI for Terraform Cloud and Terraform Enterprise"
+    license: MIT
+    formats:
+      - apk
+      - deb
+      - rpm
+    bindir: /usr/bin
+
+dockers:
+- image_templates:
+  - 'ghcr.io/straubt1/{{.ProjectName}}:{{ .Tag }}-amd64'
+  dockerfile: Dockerfile
+  use: buildx
+  build_flag_templates:
+  - "--pull"
+  - "--label=io.artifacthub.package.readme-url=https://raw.githubusercontent.com/straubt1/tfx/main/README.md"
+  - "--label=io.artifacthub.package.maintainers=[{\"name\":\"Tom Straub\",\"email\":\"straub@hashicorp.com\"}]"
+  - "--label=io.artifacthub.package.license=MIT"
+  - "--label=org.opencontainers.image.description=TFx is a standalone CLI for Terraform Cloud and Terraform Enterprise"
+  - "--label=org.opencontainers.image.created={{.Date}}"
+  - "--label=org.opencontainers.image.name={{.ProjectName}}"
+  - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+  - "--label=org.opencontainers.image.version={{.Version}}"
+  - "--label=org.opencontainers.image.source={{.GitURL}}"
+  - "--platform=linux/amd64"
+- image_templates:
+  - 'ghcr.io/straubt1/{{.ProjectName}}:{{ .Tag }}-arm64'
+  dockerfile:  Dockerfile
+  use: buildx
+  build_flag_templates:
+  - "--pull"
+  - "--label=io.artifacthub.package.readme-url=https://raw.githubusercontent.com/straubt1/tfx/main/README.md"
+  - "--label=io.artifacthub.package.maintainers=[{\"name\":\"Tom Straub\",\"email\":\"straub@hashicorp.com\"}]"
+  - "--label=io.artifacthub.package.license=MIT"
+  - "--label=org.opencontainers.image.description=TFx is a standalone CLI for Terraform Cloud and Terraform Enterprise"
+  - "--label=org.opencontainers.image.created={{.Date}}"
+  - "--label=org.opencontainers.image.name={{.ProjectName}}"
+  - "--label=org.opencontainers.image.revision={{.FullCommit}}"
+  - "--label=org.opencontainers.image.version={{.Version}}"
+  - "--label=org.opencontainers.image.source={{.GitURL}}"
+  - "--platform=linux/amd64"
+  goarch: arm64
+
+docker_manifests:
+- name_template: 'ghcr.io/straubt1/{{.ProjectName}}:{{ .Tag }}'
+  image_templates:
+  - 'ghcr.io/straubt1/{{.ProjectName}}:{{ .Tag }}-amd64'
+  - 'ghcr.io/straubt1/{{.ProjectName}}:{{ .Tag }}-arm64'
+- name_template: 'ghcr.io/straubt1/{{.ProjectName}}:latest'
+  image_templates:
+  - 'ghcr.io/straubt1/{{.ProjectName}}:{{ .Tag }}-amd64'
+  - 'ghcr.io/straubt1/{{.ProjectName}}:{{ .Tag }}-arm64'
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  use: github
+  filters:
+    exclude:
+    - '^test:'
+    - '^chore'
+    - 'merge conflict'
+    - Merge pull request
+    - Merge remote-tracking branch
+    - Merge branch
+    - go mod tidy
+  groups:
+    - title: Dependency updates
+      regexp: '^.*?(feat|fix)\(deps\)!?:.+$'
+      order: 300
+    - title: 'New Features'
+      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+      order: 100
+    - title: 'Bug fixes'
+      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+      order: 200
+    - title: 'Documentation updates'
+      regexp: ^.*?doc(\([[:word:]]+\))??!?:.+$
+      order: 400
+    - title: Other work
+      order: 9999

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine:3.18.3
+
+COPY tfx /usr/bin/tfx
+ENTRYPOINT ["/usr/bin/tfx"]


### PR DESCRIPTION
Hi Tom,

another Tom here.
We plan to use `tfx` heavily with Gitlab. To do so, we would need `tfx` packaged & released as a Container Image.

This PR adds basic functionality for Goreleaser, which would release `tfx` to `ghcr.io` (`arm64` and `amd64`) and Github Releases (`rpm`, `apk` & `deb` packages).

We could remove :
```yaml
# .github/workflows/release.yml
on:
  push:
    tags:
      - '*'
```

to run on a feature branch to make a first test run in case you consider that feature.

Regards,

Tom

