### PR TITLE
Fixed GPG output key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 **Changed**
 
+* `tfx admin gpg create` command will now output "KeyID" instead of "ID" to match the API response.
+
 **Removed**
 
 ## [v0.1.1] - 2022.09.11

--- a/cmd/admin_gpg.go
+++ b/cmd/admin_gpg.go
@@ -151,7 +151,7 @@ func gpgCreate(c TfxClientContext, namespace string, publicKey string, registryN
 	}
 
 	o.AddMessageUserProvided("GPG Key Created", "")
-	o.AddDeferredMessageRead("ID", g.ID)
+	o.AddDeferredMessageRead("KeyID", g.KeyID)
 	o.AddDeferredMessageRead("Created", FormatDateTime(g.CreatedAt))
 	o.AddDeferredMessageRead("Updated", FormatDateTime(g.UpdatedAt))
 	o.AddDeferredMessageRead("AsciiArmor", "\n"+g.AsciiArmor)

--- a/cmd/registry_provider_version_platform.go
+++ b/cmd/registry_provider_version_platform.go
@@ -145,7 +145,6 @@ func init() {
 
 	// `tfx registry provider version platform show` arguments
 	registryProviderVersionPlatformShowCmd.Flags().StringP("name", "n", "", "Name of the Provider")
-	// registryProviderVersionPlatformShowCmd.Flags().StringP("name", "n", "", "Name of the Provider")
 	registryProviderVersionPlatformShowCmd.Flags().StringP("version", "v", "", "Version of Provider (i.e. 0.0.1)")
 	registryProviderVersionPlatformShowCmd.Flags().StringP("os", "", "", "OS of the Provider Version Platform (linux, windows, darwin)")
 	registryProviderVersionPlatformShowCmd.Flags().StringP("arch", "", "", "ARCH of the Provider Version Platform (amd64, arm64)")


### PR DESCRIPTION
## Proposed Changes

  -`tfx admin gpg create` command will now output "KeyID" instead of "ID" to match the API response.
