### PR TITLE
Update GHA's

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,5 +1,5 @@
 
-name: Deploy Docs site
+name: Build and Deploy Docs https://tfx.rocks
 
 # Controls when the workflow will run
 on:
@@ -23,7 +23,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Copy Release Notes for docs site
         uses: canastro/copy-file-action@master

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Build `tfx` - Cross Compile
+name: TFx Cross Compile
 
 on:
   push:
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -25,7 +25,7 @@ jobs:
       #     version: v1.32.2
 
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: 1.21.0
       - name: Install gox
@@ -49,7 +49,7 @@ jobs:
         run: ./pkg/linux_amd64/tfx --version
         
       # Package all binaries together
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         with:
           name: tfx-artifacts
           path: ./pkg/*     

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: goreleaser
+name: TFx Release
 
 on:
   push:
@@ -17,12 +17,12 @@ jobs:
     steps:
       -
         name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
       -
         name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: 1.21
       -


### PR DESCRIPTION
Update Github Actions to avoid [Node12](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/)

https://github.com/actions/checkout
https://github.com/actions/setup-go
https://github.com/actions/upload-artifact