### PR TITLE
build: bump alpine from 3.18.3 to 3.18.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18.3
+FROM alpine:3.18.6
 
 COPY tfx /usr/bin/tfx
 ENTRYPOINT ["/usr/bin/tfx"]


### PR DESCRIPTION
## Proposed Changes

Bump Alpine Linux source for Docker image to latest [3.18-stable](https://gitlab.alpinelinux.org/alpine/aports/-/commits/3.18-stable) release (bug fixes & security updates):
 
  - [3.18.4 changes](https://alpinelinux.org/posts/Alpine-3.18.4-released.html)
  - [3.18.5 changes](https://alpinelinux.org/posts/Alpine-3.15.11-3.16.8-3.17.6-3.18.5-released.html)
  - [3.18.6 changes](https://alpinelinux.org/posts/Alpine-3.16.9-3.17.7-3.18.6-released.html)
