### PR TITLE
Add 2 additional apply-able statuses to the runCanBeApplied helper function

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,7 @@
       "request": "launch",
       "mode": "auto",
       "program": "${fileDirname}/../main.go",
-      "args": ["cv", "list", "--workspaceName=tfx-test"]
+      "args": ["cv", "list", "--workspace-name=tfx-test"]
     },
     {
       "name": "TFX - Workspace Run Show",
@@ -63,7 +63,7 @@
       "request": "launch",
       "mode": "auto",
       "program": "${fileDirname}/../main.go",
-      "args": ["apply", "--runId=run-VCMv2kHVwS4RMVRu"]
+      "args": ["apply", "--run-id=run-VCMv2kHVwS4RMVRu"]
     },
     {
       "name": "TFX - PMR List",

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -56,7 +56,6 @@ func runApply() error {
 	// Validate flags
 	hostname := *viperString("tfeHostname")
 	orgName := *viperString("tfeOrganization")
-	wsName := *viperString("workspaceName")
 	runID := *viperString("run-id")
 
 	client, ctx := getClientContext()
@@ -80,6 +79,13 @@ func runApply() error {
 	if err != nil {
 		logError(err, "failed to create apply")
 	}
+
+	// Retrieve workspace name using the ID for the URL
+	workspace, err := client.Workspaces.ReadByID(ctx, r.Workspace.ID)
+	if err != nil {
+		logError(err, "failed to read workspace")
+	}
+	wsName := workspace.Name
 
 	fmt.Println("Workspace Apply Created, Apply Id:", color.BlueString(r.Apply.ID))
 	fmt.Println("Navigate:", "https://"+hostname+"/app/"+orgName+"/workspaces/"+wsName+"/runs/"+r.ID)

--- a/cmd/helper.go
+++ b/cmd/helper.go
@@ -397,7 +397,7 @@ func createOrUpdateEnvVariables(ctx context.Context, client *tfe.Client, workspa
 
 // Determine if a run status can be applied
 func runCanBeApplied(status string) bool {
-	allowed := []string{"planned", "cost_estimated", "policy_checked"}
+	allowed := []string{"planned", "cost_estimated", "policy_checked", "post_plan_completed", "planned_and_saved"}
 
 	for _, a := range allowed {
 		if status == a {


### PR DESCRIPTION
Fixes https://github.com/straubt1/tfx/issues/195

1) Added "post_plan_completed" and "planned_and_saved" to the list of apply-able Run status. Post-plan completed happens when a post-plan run task is on the workspace. planned_and_saved is for the new saved-plan runs, which can be applied via the API like any other plan.

2) The run URL for `apply` was not interpolating correctly as workspace name is not part of the command line and not in viper - annoyingly the workspace name is also not part of the Run object and you can't even fetch it optionally with any of the [related resources](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/run#available-related-resources). I added a call to read the workspace here, but if you feel it's not warranted, we could just remove the URL completely. 

3) some of the launch.json configurations were using incorrect command lines so I fixed those.

I did test applying both kinds of new runs.