### PR TITLE
Add scoped variable set commands and variable CRUD (#219)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ logs/
 site/node_modules/
 site/dist/
 site/.astro/
+.cursor/*.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [v0.3.4] - Unreleased
 
+**Added**
+
+* Scoped variable set list: organization (default), `--project-name`, `--workspace-name`, `--all`, and `--organization-name` (#219)
+* Variable set show and delete by `--name` with scope flags for name resolution (#219)
+* Variable set create with project ownership (`--project-name`) and workspace assignment (`--workspace-name`) (#219)
+* `tfx varset variable` subcommands: `list`, `create`, `update`, `show`, `delete` (#219)
+
 **Changed**
 
 * Health check now uses `/api/v1/health/readiness` endpoint (TFE), falling back to `/_health_check` for HCP Terraform and older TFE (#244)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Variable set show and delete by `--name` with scope flags for name resolution (#219)
 * Variable set create with project ownership (`--project-name`) and workspace assignment (`--workspace-name`) (#219)
 * `tfx varset variable` subcommands: `list`, `create`, `update`, `show`, `delete` (#219)
+* Profile-based local varset lifecycle integration test (`TestVariableSetLocalProfileLifecycle`; set `TFX_INTEGRATION_PROFILE=local`)
+* `TFX_INTEGRATION_NO_CLEANUP` env var to retain varsets/variables after the lifecycle integration test
 
 **Changed**
 
@@ -20,6 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Updated task names in docs to match current Taskfile (`go-build` → `go:build`, etc.)
 * Fixed config examples in site docs to use profile block format
 * Upgraded Go to 1.26.4 and refreshed module dependencies
+
+**Fixed**
+
+* CLI commands now exit non-zero when an operation fails (`RenderError` propagates the error instead of swallowing it)
+* Integration test harness resets Cobra flag state between command invocations (fixes sticky `--env` / `--hcl` / `--sensitive` flags)
 
 ## [v0.3.3] - 2026-04-02
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -99,6 +99,34 @@ task test:integration-data
 task test:integration-cmd
 ```
 
+### Profile-based varset lifecycle test
+
+For a local TFE instance (e.g. `local.tfe.rocks`), add a profile to `~/.tfx.hcl` and run the lifecycle test:
+
+```hcl
+profile "local" {
+  hostname     = "local.tfe.rocks"
+  organization = "your-org"
+  token        = "your-token"
+}
+```
+
+```bash
+export TFX_INTEGRATION_PROFILE=local
+task test:integration-cmd -- -run TestVariableSetLocalProfileLifecycle -v
+```
+
+Optional environment variables:
+
+| Variable | Purpose |
+|---|---|
+| `TEST_PROJECT_NAME` | Also create a project-owned variable set |
+| `TEST_WORKSPACE_NAME` | Also create a workspace-assigned variable set |
+| `TFX_INTEGRATION_NO_CLEANUP=1` | Skip delete steps; leave varsets for manual inspection |
+| `TFX_CONFIG_FILE` | Explicit config file path (when not using default discovery) |
+
+See [integration/README.md](integration/README.md) for full details.
+
 ## Project Structure
 
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Check out our docs site [tfx.rocks](https://tfx.rocks)
 |---|---|
 | `tfx organization` | `list`, `show` |
 | `tfx project` | `list`, `show` |
-| `tfx variable-set` | `list`, `show`, `create`, `delete` |
+| `tfx variable-set` | `list`, `show`, `create`, `delete`, `variable` (scoped list by org/project/workspace/all) |
 | `tfx workspace` | `list`, `show` |
 | `tfx workspace configuration-version` | `list`, `show`, `create`, `download` |
 | `tfx workspace lock` | `all` |

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -7,7 +7,7 @@ Priority may change — please [open an issue](https://github.com/straubt1/tfx/i
 
 New commands and capabilities for users.
 
-- [ ] Variable Sets support
+- [x] Variable Sets support
 - [ ] `tfx team` command group
 - [ ] Cloud Agents support
 - [ ] Sentinel Publishing support

--- a/cmd/flags/varset.go
+++ b/cmd/flags/varset.go
@@ -8,52 +8,99 @@ import (
 	"github.com/spf13/viper"
 )
 
+// VariableSetScopeFlags holds shared scope flags for variable set commands.
+type VariableSetScopeFlags struct {
+	All              bool
+	OrganizationName string
+	ProjectName      string
+	WorkspaceName    string
+	Search           string
+}
+
+// ResolveVarsetOrg returns the organization name from flags or the client default.
+func ResolveVarsetOrg(flagOrg, clientOrg string) string {
+	if flagOrg != "" {
+		return flagOrg
+	}
+	return clientOrg
+}
+
+func parseVariableSetScopeFlags() VariableSetScopeFlags {
+	return VariableSetScopeFlags{
+		All:              viper.GetBool("all"),
+		OrganizationName: viper.GetString("organization-name"),
+		ProjectName:      viper.GetString("project-name"),
+		WorkspaceName:    viper.GetString("workspace-name"),
+		Search:           viper.GetString("search"),
+	}
+}
+
 // VariableSetListFlags holds flags for the variable-set list command.
 type VariableSetListFlags struct {
-	Search string
+	VariableSetScopeFlags
 }
 
 // VariableSetShowFlags holds flags for the variable-set show command.
 type VariableSetShowFlags struct {
-	ID string
+	ID   string
+	Name string
+	VariableSetScopeFlags
 }
 
 // VariableSetCreateFlags holds flags for the variable-set create command.
 type VariableSetCreateFlags struct {
-	Name        string
-	Description string
-	Global      bool
-	Priority    bool
+	Name             string
+	Description      string
+	Global           bool
+	Priority         bool
+	OrganizationName string
+	ProjectName      string
+	WorkspaceName    string
 }
 
 // VariableSetDeleteFlags holds flags for the variable-set delete command.
 type VariableSetDeleteFlags struct {
-	ID string
+	ID   string
+	Name string
+	VariableSetScopeFlags
 }
 
 func ParseVariableSetListFlags(cmd *cobra.Command) (*VariableSetListFlags, error) {
 	return &VariableSetListFlags{
-		Search: viper.GetString("search"),
+		VariableSetScopeFlags: parseVariableSetScopeFlags(),
 	}, nil
 }
 
 func ParseVariableSetShowFlags(cmd *cobra.Command) (*VariableSetShowFlags, error) {
 	return &VariableSetShowFlags{
-		ID: viper.GetString("id"),
+		ID:                    viper.GetString("id"),
+		Name:                  viper.GetString("name"),
+		VariableSetScopeFlags: parseVariableSetScopeFlagsWithoutSearch(),
 	}, nil
 }
 
 func ParseVariableSetCreateFlags(cmd *cobra.Command) (*VariableSetCreateFlags, error) {
 	return &VariableSetCreateFlags{
-		Name:        viper.GetString("name"),
-		Description: viper.GetString("description"),
-		Global:      viper.GetBool("global"),
-		Priority:    viper.GetBool("priority"),
+		Name:             viper.GetString("name"),
+		Description:      viper.GetString("description"),
+		Global:           viper.GetBool("global"),
+		Priority:         viper.GetBool("priority"),
+		OrganizationName: viper.GetString("organization-name"),
+		ProjectName:      viper.GetString("project-name"),
+		WorkspaceName:    viper.GetString("workspace-name"),
 	}, nil
 }
 
 func ParseVariableSetDeleteFlags(cmd *cobra.Command) (*VariableSetDeleteFlags, error) {
 	return &VariableSetDeleteFlags{
-		ID: viper.GetString("id"),
+		ID:                    viper.GetString("id"),
+		Name:                  viper.GetString("name"),
+		VariableSetScopeFlags: parseVariableSetScopeFlagsWithoutSearch(),
 	}, nil
+}
+
+func parseVariableSetScopeFlagsWithoutSearch() VariableSetScopeFlags {
+	f := parseVariableSetScopeFlags()
+	f.Search = ""
+	return f
 }

--- a/cmd/flags/varset_variable.go
+++ b/cmd/flags/varset_variable.go
@@ -1,0 +1,116 @@
+// Copyright (c) Tom Straub (github.com/straubt1) 2025
+// SPDX-License-Identifier: MIT
+
+package flags
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// VariableSetVariableListFlags holds flags for the variable-set variable list command.
+type VariableSetVariableListFlags struct {
+	VarsetName string
+	VarsetID   string
+	VariableSetScopeFlags
+}
+
+// VariableSetVariableShowFlags holds flags for the variable-set variable show command.
+type VariableSetVariableShowFlags struct {
+	VarsetName string
+	VarsetID   string
+	Key        string
+	VariableSetScopeFlags
+}
+
+// VariableSetVariableCreateFlags holds flags for the variable-set variable create command.
+type VariableSetVariableCreateFlags struct {
+	VarsetName  string
+	VarsetID    string
+	Key         string
+	Value       string
+	ValueFile   string
+	Description string
+	Env         bool
+	HCL         bool
+	Sensitive   bool
+	VariableSetScopeFlags
+}
+
+// VariableSetVariableUpdateFlags holds flags for the variable-set variable update command.
+type VariableSetVariableUpdateFlags struct {
+	VarsetName  string
+	VarsetID    string
+	Key         string
+	Value       string
+	ValueFile   string
+	Description string
+	Env         bool
+	HCL         bool
+	Sensitive   bool
+	VariableSetScopeFlags
+}
+
+// VariableSetVariableDeleteFlags holds flags for the variable-set variable delete command.
+type VariableSetVariableDeleteFlags struct {
+	VarsetName string
+	VarsetID   string
+	Key        string
+	VariableSetScopeFlags
+}
+
+func ParseVariableSetVariableListFlags(cmd *cobra.Command) (*VariableSetVariableListFlags, error) {
+	return &VariableSetVariableListFlags{
+		VarsetName:            viper.GetString("varset-name"),
+		VarsetID:              viper.GetString("varset-id"),
+		VariableSetScopeFlags: parseVariableSetScopeFlagsWithoutSearch(),
+	}, nil
+}
+
+func ParseVariableSetVariableShowFlags(cmd *cobra.Command) (*VariableSetVariableShowFlags, error) {
+	return &VariableSetVariableShowFlags{
+		VarsetName:            viper.GetString("varset-name"),
+		VarsetID:              viper.GetString("varset-id"),
+		Key:                   viper.GetString("key"),
+		VariableSetScopeFlags: parseVariableSetScopeFlagsWithoutSearch(),
+	}, nil
+}
+
+func ParseVariableSetVariableCreateFlags(cmd *cobra.Command) (*VariableSetVariableCreateFlags, error) {
+	return &VariableSetVariableCreateFlags{
+		VarsetName:            viper.GetString("varset-name"),
+		VarsetID:              viper.GetString("varset-id"),
+		Key:                   viper.GetString("key"),
+		Value:                 viper.GetString("value"),
+		ValueFile:             viper.GetString("value-file"),
+		Description:           viper.GetString("description"),
+		Env:                   viper.GetBool("env"),
+		HCL:                   viper.GetBool("hcl"),
+		Sensitive:             viper.GetBool("sensitive"),
+		VariableSetScopeFlags: parseVariableSetScopeFlagsWithoutSearch(),
+	}, nil
+}
+
+func ParseVariableSetVariableUpdateFlags(cmd *cobra.Command) (*VariableSetVariableUpdateFlags, error) {
+	return &VariableSetVariableUpdateFlags{
+		VarsetName:            viper.GetString("varset-name"),
+		VarsetID:              viper.GetString("varset-id"),
+		Key:                   viper.GetString("key"),
+		Value:                 viper.GetString("value"),
+		ValueFile:             viper.GetString("value-file"),
+		Description:           viper.GetString("description"),
+		Env:                   viper.GetBool("env"),
+		HCL:                   viper.GetBool("hcl"),
+		Sensitive:             viper.GetBool("sensitive"),
+		VariableSetScopeFlags: parseVariableSetScopeFlagsWithoutSearch(),
+	}, nil
+}
+
+func ParseVariableSetVariableDeleteFlags(cmd *cobra.Command) (*VariableSetVariableDeleteFlags, error) {
+	return &VariableSetVariableDeleteFlags{
+		VarsetName:            viper.GetString("varset-name"),
+		VarsetID:              viper.GetString("varset-id"),
+		Key:                   viper.GetString("key"),
+		VariableSetScopeFlags: parseVariableSetScopeFlagsWithoutSearch(),
+	}, nil
+}

--- a/cmd/varset.go
+++ b/cmd/varset.go
@@ -81,21 +81,34 @@ var (
 func init() {
 	// `tfx variable-set list` flags
 	varsetListCmd.Flags().StringP("search", "s", "", "Search string to filter variable sets by name (optional).")
+	varsetListCmd.Flags().BoolP("all", "a", false, "List variable sets across all organizations (optional).")
+	addVarsetScopeFlags(varsetListCmd)
+	varsetListCmd.MarkFlagsMutuallyExclusive("all", "project-name", "workspace-name")
 
 	// `tfx variable-set show` flags
-	varsetShowCmd.Flags().StringP("id", "i", "", "ID of the Variable Set (required).")
-	varsetShowCmd.MarkFlagRequired("id")
+	varsetShowCmd.Flags().StringP("id", "i", "", "ID of the Variable Set.")
+	varsetShowCmd.Flags().StringP("name", "n", "", "Name of the Variable Set.")
+	addVarsetScopeFlags(varsetShowCmd)
+	varsetShowCmd.MarkFlagsMutuallyExclusive("id", "name")
+	varsetShowCmd.MarkFlagsOneRequired("id", "name")
 
 	// `tfx variable-set create` flags
 	varsetCreateCmd.Flags().StringP("name", "n", "", "Name of the Variable Set (required).")
 	varsetCreateCmd.Flags().StringP("description", "d", "", "Description of the Variable Set (optional).")
 	varsetCreateCmd.Flags().Bool("global", false, "Apply this Variable Set to all workspaces in the organization (optional).")
 	varsetCreateCmd.Flags().Bool("priority", false, "Variable values in this set override workspace-level values (optional).")
+	varsetCreateCmd.Flags().String("organization-name", "", "Organization name (optional, defaults to configured organization).")
+	varsetCreateCmd.Flags().String("project-name", "", "Create as a project-owned variable set (optional).")
+	varsetCreateCmd.Flags().String("workspace-name", "", "Apply the variable set to this workspace after creation (optional).")
 	varsetCreateCmd.MarkFlagRequired("name")
+	varsetCreateCmd.MarkFlagsMutuallyExclusive("global", "project-name")
 
 	// `tfx variable-set delete` flags
-	varsetDeleteCmd.Flags().StringP("id", "i", "", "ID of the Variable Set to delete (required).")
-	varsetDeleteCmd.MarkFlagRequired("id")
+	varsetDeleteCmd.Flags().StringP("id", "i", "", "ID of the Variable Set to delete.")
+	varsetDeleteCmd.Flags().StringP("name", "n", "", "Name of the Variable Set to delete.")
+	addVarsetScopeFlags(varsetDeleteCmd)
+	varsetDeleteCmd.MarkFlagsMutuallyExclusive("id", "name")
+	varsetDeleteCmd.MarkFlagsOneRequired("id", "name")
 
 	rootCmd.AddCommand(varsetCmd)
 	varsetCmd.AddCommand(varsetListCmd)
@@ -104,18 +117,78 @@ func init() {
 	varsetCmd.AddCommand(varsetDeleteCmd)
 }
 
+func addVarsetScopeFlags(cmd *cobra.Command) {
+	cmd.Flags().String("organization-name", "", "Organization name (optional, defaults to configured organization).")
+	cmd.Flags().String("project-name", "", "Filter or scope to a project (optional).")
+	cmd.Flags().String("workspace-name", "", "Filter or scope to a workspace (optional).")
+}
+
+func variableSetScopeFromFlags(f flags.VariableSetScopeFlags) data.VariableSetScope {
+	return data.VariableSetScope{
+		All:              f.All,
+		OrganizationName: f.OrganizationName,
+		ProjectName:      f.ProjectName,
+		WorkspaceName:    f.WorkspaceName,
+		Search:           f.Search,
+	}
+}
+
+func varsetScopeFromListFlags(f *flags.VariableSetListFlags) data.VariableSetScope {
+	return variableSetScopeFromFlags(f.VariableSetScopeFlags)
+}
+
+func varsetListHeader(v *view.VariableSetListView, c *client.TfxClient, f *flags.VariableSetListFlags) {
+	if f.All {
+		if f.Search != "" {
+			v.PrintCommandHeader("Listing variable sets across all organizations matching '%s'", f.Search)
+		} else {
+			v.PrintCommandHeader("Listing variable sets across all organizations")
+		}
+		return
+	}
+
+	org := flags.ResolveVarsetOrg(f.OrganizationName, c.OrganizationName)
+
+	if f.WorkspaceName != "" {
+		if f.Search != "" {
+			v.PrintCommandHeader("Listing variable sets for workspace '%s' in organization '%s' matching '%s'", f.WorkspaceName, org, f.Search)
+		} else {
+			v.PrintCommandHeader("Listing variable sets for workspace '%s' in organization '%s'", f.WorkspaceName, org)
+		}
+		return
+	}
+
+	if f.ProjectName != "" {
+		if f.Search != "" {
+			v.PrintCommandHeader("Listing variable sets for project '%s' in organization '%s' matching '%s'", f.ProjectName, org, f.Search)
+		} else {
+			v.PrintCommandHeader("Listing variable sets for project '%s' in organization '%s'", f.ProjectName, org)
+		}
+		return
+	}
+
+	if f.Search != "" {
+		v.PrintCommandHeader("Listing variable sets in organization '%s' matching '%s'", org, f.Search)
+	} else {
+		v.PrintCommandHeader("Listing variable sets in organization '%s'", org)
+	}
+}
+
 func variableSetList(cmdConfig *flags.VariableSetListFlags) error {
 	v := view.NewVariableSetListView()
 	c, err := client.NewFromViper()
 	if err != nil {
 		return v.RenderError(err)
 	}
-	v.PrintCommandHeader("List Variable Sets for Organization: %s", c.OrganizationName)
-	items, err := data.ListVariableSets(c, c.OrganizationName, cmdConfig.Search)
+
+	varsetListHeader(v, c, cmdConfig)
+
+	scope := varsetScopeFromListFlags(cmdConfig)
+	items, err := data.ListVariableSetsWithScope(c, c.OrganizationName, scope)
 	if err != nil {
 		return v.RenderError(errors.Wrap(err, "failed to list variable sets"))
 	}
-	return v.Render(items)
+	return v.Render(items, cmdConfig.All)
 }
 
 func variableSetShow(cmdConfig *flags.VariableSetShowFlags) error {
@@ -124,8 +197,15 @@ func variableSetShow(cmdConfig *flags.VariableSetShowFlags) error {
 	if err != nil {
 		return v.RenderError(err)
 	}
-	v.PrintCommandHeader("Show Variable Set: %s", cmdConfig.ID)
-	vs, err := data.ReadVariableSet(c, cmdConfig.ID)
+
+	scope := variableSetScopeFromFlags(cmdConfig.VariableSetScopeFlags)
+	if cmdConfig.ID != "" {
+		v.PrintCommandHeader("Showing variable set '%s'", cmdConfig.ID)
+	} else {
+		v.PrintCommandHeader("Showing variable set '%s'", cmdConfig.Name)
+	}
+
+	vs, err := data.ResolveVariableSet(c, c.OrganizationName, scope, cmdConfig.Name, cmdConfig.ID)
 	if err != nil {
 		return v.RenderError(errors.Wrap(err, "failed to read variable set"))
 	}
@@ -138,8 +218,19 @@ func variableSetCreate(cmdConfig *flags.VariableSetCreateFlags) error {
 	if err != nil {
 		return v.RenderError(err)
 	}
-	v.PrintCommandHeader("Create Variable Set for Organization: %s", c.OrganizationName)
-	vs, err := data.CreateVariableSet(c, c.OrganizationName, cmdConfig.Name, cmdConfig.Description, cmdConfig.Global, cmdConfig.Priority)
+
+	orgName := flags.ResolveVarsetOrg(cmdConfig.OrganizationName, c.OrganizationName)
+	v.PrintCommandHeader("Creating variable set '%s' in organization '%s'", cmdConfig.Name, orgName)
+
+	params := data.VariableSetCreateParams{
+		Name:          cmdConfig.Name,
+		Description:   cmdConfig.Description,
+		Global:        cmdConfig.Global,
+		Priority:      cmdConfig.Priority,
+		ProjectName:   cmdConfig.ProjectName,
+		WorkspaceName: cmdConfig.WorkspaceName,
+	}
+	vs, err := data.CreateVariableSet(c, orgName, params)
 	if err != nil {
 		return v.RenderError(errors.Wrap(err, "failed to create variable set"))
 	}
@@ -152,10 +243,22 @@ func variableSetDelete(cmdConfig *flags.VariableSetDeleteFlags) error {
 	if err != nil {
 		return v.RenderError(err)
 	}
-	v.PrintCommandHeader("Delete Variable Set: %s", cmdConfig.ID)
-	err = data.DeleteVariableSet(c, cmdConfig.ID)
+
+	scope := variableSetScopeFromFlags(cmdConfig.VariableSetScopeFlags)
+	label := cmdConfig.ID
+	if label == "" {
+		label = cmdConfig.Name
+	}
+	v.PrintCommandHeader("Deleting variable set '%s'", label)
+
+	vs, err := data.ResolveVariableSet(c, c.OrganizationName, scope, cmdConfig.Name, cmdConfig.ID)
+	if err != nil {
+		return v.RenderError(errors.Wrap(err, "failed to resolve variable set"))
+	}
+
+	err = data.DeleteVariableSet(c, vs.ID)
 	if err != nil {
 		return v.RenderError(errors.Wrap(err, "failed to delete variable set"))
 	}
-	return v.Render(cmdConfig.ID)
+	return v.Render(vs.ID)
 }

--- a/cmd/varset_variable.go
+++ b/cmd/varset_variable.go
@@ -1,0 +1,345 @@
+// Copyright (c) Tom Straub (github.com/straubt1) 2025
+// SPDX-License-Identifier: MIT
+
+package cmd
+
+import (
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/straubt1/tfx/client"
+	"github.com/straubt1/tfx/cmd/flags"
+	view "github.com/straubt1/tfx/cmd/views"
+	"github.com/straubt1/tfx/data"
+	pkgfile "github.com/straubt1/tfx/pkg/file"
+)
+
+var (
+	// `tfx variable-set variable` command
+	varsetVariableCmd = &cobra.Command{
+		Use:     "variable",
+		Aliases: []string{"var"},
+		Short:   "Variable Set Variable Commands",
+		Long:    "Commands to work with Variables in a Variable Set.",
+	}
+
+	// `tfx variable-set variable list` command
+	varsetVariableListCmd = &cobra.Command{
+		Use:   "list",
+		Short: "List Variables",
+		Long:  "List Variables in a Variable Set.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdConfig, err := flags.ParseVariableSetVariableListFlags(cmd)
+			if err != nil {
+				return err
+			}
+			return variableSetVariableList(cmdConfig)
+		},
+	}
+
+	// `tfx variable-set variable create` command
+	varsetVariableCreateCmd = &cobra.Command{
+		Use:   "create",
+		Short: "Create a Variable",
+		Long:  "Create a Variable in a Variable Set.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdConfig, err := flags.ParseVariableSetVariableCreateFlags(cmd)
+			if err != nil {
+				return err
+			}
+			return variableSetVariableCreate(cmdConfig)
+		},
+	}
+
+	// `tfx variable-set variable update` command
+	varsetVariableUpdateCmd = &cobra.Command{
+		Use:   "update",
+		Short: "Update a Variable",
+		Long:  "Update a Variable in a Variable Set.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdConfig, err := flags.ParseVariableSetVariableUpdateFlags(cmd)
+			if err != nil {
+				return err
+			}
+			return variableSetVariableUpdate(cmdConfig)
+		},
+	}
+
+	// `tfx variable-set variable show` command
+	varsetVariableShowCmd = &cobra.Command{
+		Use:   "show",
+		Short: "Show details of a Variable",
+		Long:  "Show details of a Variable in a Variable Set.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdConfig, err := flags.ParseVariableSetVariableShowFlags(cmd)
+			if err != nil {
+				return err
+			}
+			return variableSetVariableShow(cmdConfig)
+		},
+	}
+
+	// `tfx variable-set variable delete` command
+	varsetVariableDeleteCmd = &cobra.Command{
+		Use:   "delete",
+		Short: "Delete a Variable",
+		Long:  "Delete a Variable in a Variable Set.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cmdConfig, err := flags.ParseVariableSetVariableDeleteFlags(cmd)
+			if err != nil {
+				return err
+			}
+			return variableSetVariableDelete(cmdConfig)
+		},
+	}
+)
+
+func init() {
+	addVarsetVariableCommonFlags(varsetVariableListCmd)
+	varsetVariableListCmd.MarkFlagsOneRequired("varset-id", "varset-name")
+
+	addVarsetVariableCommonFlags(varsetVariableCreateCmd)
+	varsetVariableCreateCmd.Flags().StringP("key", "k", "", "Key of the Variable")
+	varsetVariableCreateCmd.Flags().StringP("value", "v", "", "Value of the Variable (value or value-file must be set)")
+	varsetVariableCreateCmd.Flags().StringP("value-file", "f", "", "Path to a variable text file, the contents of the file will be used (value or value-file must be set)")
+	varsetVariableCreateCmd.Flags().StringP("description", "d", "", "Description of the Variable (optional)")
+	varsetVariableCreateCmd.Flags().BoolP("env", "e", false, "Variable is an Environment Variable (optional, defaults to false)")
+	varsetVariableCreateCmd.Flags().BoolP("hcl", "", false, "Value of Variable is HCL (optional, defaults to false)")
+	varsetVariableCreateCmd.Flags().BoolP("sensitive", "s", false, "Variable is Sensitive (optional, defaults to false)")
+	varsetVariableCreateCmd.MarkFlagsOneRequired("varset-id", "varset-name")
+	varsetVariableCreateCmd.MarkFlagRequired("key")
+	varsetVariableCreateCmd.MarkFlagsMutuallyExclusive("value", "value-file")
+	varsetVariableCreateCmd.MarkFlagsOneRequired("value", "value-file")
+
+	addVarsetVariableCommonFlags(varsetVariableUpdateCmd)
+	varsetVariableUpdateCmd.Flags().StringP("key", "k", "", "Key of the Variable")
+	varsetVariableUpdateCmd.Flags().StringP("value", "v", "", "Value of the Variable (value or value-file must be set)")
+	varsetVariableUpdateCmd.Flags().StringP("value-file", "f", "", "Path to a variable text file, the contents of the file will be used (value or value-file must be set)")
+	varsetVariableUpdateCmd.Flags().StringP("description", "d", "", "Description of the Variable (optional)")
+	varsetVariableUpdateCmd.Flags().BoolP("env", "e", false, "Variable is an Environment Variable (optional, defaults to false)")
+	varsetVariableUpdateCmd.Flags().BoolP("hcl", "", false, "Value of Variable is HCL (optional, defaults to false)")
+	varsetVariableUpdateCmd.Flags().BoolP("sensitive", "s", false, "Variable is Sensitive (optional, defaults to false)")
+	varsetVariableUpdateCmd.MarkFlagsOneRequired("varset-id", "varset-name")
+	varsetVariableUpdateCmd.MarkFlagRequired("key")
+	varsetVariableUpdateCmd.MarkFlagsMutuallyExclusive("value", "value-file")
+	varsetVariableUpdateCmd.MarkFlagsOneRequired("value", "value-file")
+
+	addVarsetVariableCommonFlags(varsetVariableShowCmd)
+	varsetVariableShowCmd.Flags().StringP("key", "k", "", "Key of the Variable")
+	varsetVariableShowCmd.MarkFlagsOneRequired("varset-id", "varset-name")
+	varsetVariableShowCmd.MarkFlagRequired("key")
+
+	addVarsetVariableCommonFlags(varsetVariableDeleteCmd)
+	varsetVariableDeleteCmd.Flags().StringP("key", "k", "", "Key of the Variable")
+	varsetVariableDeleteCmd.MarkFlagsOneRequired("varset-id", "varset-name")
+	varsetVariableDeleteCmd.MarkFlagRequired("key")
+
+	varsetCmd.AddCommand(varsetVariableCmd)
+	varsetVariableCmd.AddCommand(varsetVariableListCmd)
+	varsetVariableCmd.AddCommand(varsetVariableCreateCmd)
+	varsetVariableCmd.AddCommand(varsetVariableUpdateCmd)
+	varsetVariableCmd.AddCommand(varsetVariableShowCmd)
+	varsetVariableCmd.AddCommand(varsetVariableDeleteCmd)
+}
+
+func addVarsetVariableCommonFlags(cmd *cobra.Command) {
+	cmd.Flags().String("varset-id", "", "ID of the Variable Set")
+	cmd.Flags().String("varset-name", "", "Name of the Variable Set")
+	cmd.Flags().String("organization-name", "", "Organization name (optional, defaults to configured organization).")
+	cmd.Flags().String("project-name", "", "Scope for resolving the variable set by name (optional).")
+	cmd.Flags().String("workspace-name", "", "Scope for resolving the variable set by name (optional).")
+	cmd.MarkFlagsMutuallyExclusive("varset-id", "varset-name")
+}
+
+func resolveVariableSetForVariableCmd(c *client.TfxClient, varsetName, varsetID string, scope flags.VariableSetScopeFlags) (*tfe.VariableSet, error) {
+	return data.ResolveVariableSet(c, c.OrganizationName, variableSetScopeFromFlags(scope), varsetName, varsetID)
+}
+
+func variableSetVariableList(cmdConfig *flags.VariableSetVariableListFlags) error {
+	v := view.NewVariableSetVariableListView()
+
+	c, err := client.NewFromViper()
+	if err != nil {
+		return v.RenderError(err)
+	}
+
+	label := cmdConfig.VarsetID
+	if label == "" {
+		label = cmdConfig.VarsetName
+	}
+	v.PrintCommandHeader("Listing variables for variable set '%s'", label)
+
+	vs, err := resolveVariableSetForVariableCmd(c, cmdConfig.VarsetName, cmdConfig.VarsetID, cmdConfig.VariableSetScopeFlags)
+	if err != nil {
+		return v.RenderError(errors.Wrap(err, "failed to resolve variable set"))
+	}
+
+	variables, err := data.FetchVariableSetVariables(c, vs.ID)
+	if err != nil {
+		return v.RenderError(errors.Wrap(err, "failed to list variables"))
+	}
+
+	return v.Render(variables)
+}
+
+func variableSetVariableCreate(cmdConfig *flags.VariableSetVariableCreateFlags) error {
+	v := view.NewVariableSetVariableCreateView()
+
+	c, err := client.NewFromViper()
+	if err != nil {
+		return v.RenderError(err)
+	}
+
+	label := cmdConfig.VarsetID
+	if label == "" {
+		label = cmdConfig.VarsetName
+	}
+	v.PrintCommandHeader("Creating variable '%s' for variable set '%s'", cmdConfig.Key, label)
+
+	vs, err := resolveVariableSetForVariableCmd(c, cmdConfig.VarsetName, cmdConfig.VarsetID, cmdConfig.VariableSetScopeFlags)
+	if err != nil {
+		return v.RenderError(errors.Wrap(err, "failed to resolve variable set"))
+	}
+
+	value := cmdConfig.Value
+	if cmdConfig.ValueFile != "" {
+		if !pkgfile.IsFile(cmdConfig.ValueFile) {
+			return v.RenderError(errors.New("valueFile does not exist"))
+		}
+		v.PrintCommandFilter("Variable filename contents will be used: %s", cmdConfig.ValueFile)
+		value, err = pkgfile.ReadFile(cmdConfig.ValueFile)
+		if err != nil {
+			return v.RenderError(errors.Wrap(err, "unable to read the file passed"))
+		}
+	}
+
+	var category *tfe.CategoryType
+	if cmdConfig.Env {
+		category = tfe.Category(tfe.CategoryEnv)
+	} else {
+		category = tfe.Category(tfe.CategoryTerraform)
+	}
+
+	variable, err := data.CreateVariableSetVariable(c, vs.ID, tfe.VariableSetVariableCreateOptions{
+		Key:         &cmdConfig.Key,
+		Value:       &value,
+		Description: &cmdConfig.Description,
+		Category:    category,
+		HCL:         &cmdConfig.HCL,
+		Sensitive:   &cmdConfig.Sensitive,
+	})
+	if err != nil {
+		return v.RenderError(errors.Wrap(err, "failed to create variable"))
+	}
+
+	return v.Render(variable)
+}
+
+func variableSetVariableUpdate(cmdConfig *flags.VariableSetVariableUpdateFlags) error {
+	v := view.NewVariableSetVariableUpdateView()
+
+	c, err := client.NewFromViper()
+	if err != nil {
+		return v.RenderError(err)
+	}
+
+	label := cmdConfig.VarsetID
+	if label == "" {
+		label = cmdConfig.VarsetName
+	}
+	v.PrintCommandHeader("Updating variable '%s' for variable set '%s'", cmdConfig.Key, label)
+
+	vs, err := resolveVariableSetForVariableCmd(c, cmdConfig.VarsetName, cmdConfig.VarsetID, cmdConfig.VariableSetScopeFlags)
+	if err != nil {
+		return v.RenderError(errors.Wrap(err, "failed to resolve variable set"))
+	}
+
+	variableID, err := data.GetVariableSetVariableID(c, vs.ID, cmdConfig.Key)
+	if err != nil {
+		return v.RenderError(errors.Wrap(err, "unable to read variable id"))
+	}
+
+	value := cmdConfig.Value
+	if cmdConfig.ValueFile != "" {
+		if !pkgfile.IsFile(cmdConfig.ValueFile) {
+			return v.RenderError(errors.New("valueFile does not exist"))
+		}
+		v.PrintCommandFilter("Variable filename contents will be used: %s", cmdConfig.ValueFile)
+		value, err = pkgfile.ReadFile(cmdConfig.ValueFile)
+		if err != nil {
+			return v.RenderError(errors.Wrap(err, "unable to read the file passed"))
+		}
+	}
+
+	variable, err := data.UpdateVariableSetVariable(c, vs.ID, variableID, tfe.VariableSetVariableUpdateOptions{
+		Key:         &cmdConfig.Key,
+		Value:       &value,
+		Description: &cmdConfig.Description,
+		HCL:         &cmdConfig.HCL,
+		Sensitive:   &cmdConfig.Sensitive,
+	})
+	if err != nil {
+		return v.RenderError(errors.Wrap(err, "failed to update variable"))
+	}
+
+	return v.Render(variable)
+}
+
+func variableSetVariableShow(cmdConfig *flags.VariableSetVariableShowFlags) error {
+	v := view.NewVariableSetVariableShowView()
+
+	c, err := client.NewFromViper()
+	if err != nil {
+		return v.RenderError(err)
+	}
+
+	label := cmdConfig.VarsetID
+	if label == "" {
+		label = cmdConfig.VarsetName
+	}
+	v.PrintCommandHeader("Showing variable '%s' for variable set '%s'", cmdConfig.Key, label)
+
+	vs, err := resolveVariableSetForVariableCmd(c, cmdConfig.VarsetName, cmdConfig.VarsetID, cmdConfig.VariableSetScopeFlags)
+	if err != nil {
+		return v.RenderError(errors.Wrap(err, "failed to resolve variable set"))
+	}
+
+	variable, err := data.FetchVariableSetVariable(c, vs.ID, cmdConfig.Key)
+	if err != nil {
+		return v.RenderError(errors.Wrap(err, "unable to read variable"))
+	}
+
+	return v.Render(variable)
+}
+
+func variableSetVariableDelete(cmdConfig *flags.VariableSetVariableDeleteFlags) error {
+	v := view.NewVariableSetVariableDeleteView()
+
+	c, err := client.NewFromViper()
+	if err != nil {
+		return v.RenderError(err)
+	}
+
+	label := cmdConfig.VarsetID
+	if label == "" {
+		label = cmdConfig.VarsetName
+	}
+	v.PrintCommandHeader("Deleting variable '%s' for variable set '%s'", cmdConfig.Key, label)
+
+	vs, err := resolveVariableSetForVariableCmd(c, cmdConfig.VarsetName, cmdConfig.VarsetID, cmdConfig.VariableSetScopeFlags)
+	if err != nil {
+		return v.RenderError(errors.Wrap(err, "failed to resolve variable set"))
+	}
+
+	variableID, err := data.GetVariableSetVariableID(c, vs.ID, cmdConfig.Key)
+	if err != nil {
+		return v.RenderError(errors.Wrap(err, "unable to read variable id"))
+	}
+
+	err = data.DeleteVariableSetVariable(c, vs.ID, variableID)
+	if err != nil {
+		return v.RenderError(errors.Wrap(err, "failed to delete variable"))
+	}
+
+	return v.Render(cmdConfig.Key)
+}

--- a/cmd/views/variable_set_list.go
+++ b/cmd/views/variable_set_list.go
@@ -40,23 +40,45 @@ func parseVariableSetParent(vs *tfe.VariableSet) (out variableSetParentOutput) {
 }
 
 type variableSetListOutput struct {
-	ID          string                  `json:"id"`
-	Name        string                  `json:"name"`
-	Description string                  `json:"description"`
-	Global      bool                    `json:"global"`
-	Priority    bool                    `json:"priority"`
-	Parent      variableSetParentOutput `json:"parent"`
+	Organization string                  `json:"organization,omitempty"`
+	ID           string                  `json:"id"`
+	Name         string                  `json:"name"`
+	Description  string                  `json:"description"`
+	Global       bool                    `json:"global"`
+	Priority     bool                    `json:"priority"`
+	Parent       variableSetParentOutput `json:"parent"`
 }
 
-func (v *VariableSetListView) Render(items []*tfe.VariableSet) error {
+// Render renders variable sets for a single organization or across all organizations.
+// If includeOrgColumn is true, the organization column will be included in the terminal output.
+func (v *VariableSetListView) Render(items []*tfe.VariableSet, includeOrgColumn bool) error {
 	if v.IsJSON() {
 		out := make([]variableSetListOutput, len(items))
 		for i, vs := range items {
-			out[i] = variableSetListOutput{ID: vs.ID, Name: vs.Name, Description: vs.Description, Global: vs.Global, Priority: vs.Priority, Parent: parseVariableSetParent(vs)}
+			orgName := ""
+			if vs.Organization != nil {
+				orgName = vs.Organization.Name
+			}
+			out[i] = variableSetListOutput{
+				Organization: orgName,
+				ID:           vs.ID,
+				Name:         vs.Name,
+				Description:  vs.Description,
+				Global:       vs.Global,
+				Priority:     vs.Priority,
+				Parent:       parseVariableSetParent(vs),
+			}
 		}
 		return v.Output().RenderJSON(out)
 	}
-	headers := []string{"Name", "ID", "Global", "Priority", "Parent"}
+
+	var headers []string
+	if includeOrgColumn {
+		headers = []string{"Organization", "Name", "ID", "Global", "Priority", "Parent"}
+	} else {
+		headers = []string{"Name", "ID", "Global", "Priority", "Parent"}
+	}
+
 	rows := make([][]interface{}, len(items))
 	for i, vs := range items {
 		parent := parseVariableSetParent(vs)
@@ -64,7 +86,15 @@ func (v *VariableSetListView) Render(items []*tfe.VariableSet) error {
 		if parent.Type != "" {
 			parentDisplay = parent.Type + ":" + parent.ID
 		}
-		rows[i] = []interface{}{vs.Name, vs.ID, vs.Global, vs.Priority, parentDisplay}
+		if includeOrgColumn {
+			orgName := ""
+			if vs.Organization != nil {
+				orgName = vs.Organization.Name
+			}
+			rows[i] = []interface{}{orgName, vs.Name, vs.ID, vs.Global, vs.Priority, parentDisplay}
+		} else {
+			rows[i] = []interface{}{vs.Name, vs.ID, vs.Global, vs.Priority, parentDisplay}
+		}
 	}
 	return v.Output().RenderTable(headers, rows)
 }

--- a/cmd/views/variable_set_variable_create.go
+++ b/cmd/views/variable_set_variable_create.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+// Copyright © 2025 Tom Straub <github.com/straubt1>
+
+package view
+
+import (
+	tfe "github.com/hashicorp/go-tfe"
+)
+
+// VariableSetVariableCreateView handles rendering for variable set variable create command
+type VariableSetVariableCreateView struct {
+	*BaseView
+}
+
+func NewVariableSetVariableCreateView() *VariableSetVariableCreateView {
+	return &VariableSetVariableCreateView{
+		BaseView: NewBaseView(),
+	}
+}
+
+// Render renders a created variable set variable's details
+func (v *VariableSetVariableCreateView) Render(variable *tfe.VariableSetVariable) error {
+	if v.IsJSON() {
+		output := variableSetVariableShowOutput{
+			ID:          variable.ID,
+			Key:         variable.Key,
+			Value:       variable.Value,
+			Sensitive:   variable.Sensitive,
+			HCL:         variable.HCL,
+			Category:    string(variable.Category),
+			Description: variable.Description,
+		}
+		return v.Output().RenderJSON(output)
+	}
+
+	properties := []PropertyPair{
+		{Key: "ID", Value: variable.ID},
+		{Key: "Key", Value: variable.Key},
+		{Key: "Value", Value: variable.Value},
+		{Key: "Sensitive", Value: variable.Sensitive},
+		{Key: "HCL", Value: variable.HCL},
+		{Key: "Category", Value: variable.Category},
+		{Key: "Description", Value: variable.Description},
+	}
+
+	return v.Output().RenderProperties(properties)
+}

--- a/cmd/views/variable_set_variable_delete.go
+++ b/cmd/views/variable_set_variable_delete.go
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+// Copyright © 2025 Tom Straub <github.com/straubt1>
+
+package view
+
+// VariableSetVariableDeleteView handles rendering for variable set variable delete command
+type VariableSetVariableDeleteView struct {
+	*BaseView
+}
+
+func NewVariableSetVariableDeleteView() *VariableSetVariableDeleteView {
+	return &VariableSetVariableDeleteView{
+		BaseView: NewBaseView(),
+	}
+}
+
+// variableSetVariableDeleteOutput is a JSON-safe representation of a delete operation
+type variableSetVariableDeleteOutput struct {
+	Status string `json:"status"`
+	Key    string `json:"key"`
+}
+
+// Render renders a successful delete operation
+func (v *VariableSetVariableDeleteView) Render(key string) error {
+	if v.IsJSON() {
+		output := variableSetVariableDeleteOutput{
+			Status: "Success",
+			Key:    key,
+		}
+		return v.Output().RenderJSON(output)
+	}
+
+	properties := []PropertyPair{
+		{Key: "Status", Value: "Success"},
+		{Key: "Key", Value: key},
+	}
+
+	return v.Output().RenderProperties(properties)
+}

--- a/cmd/views/variable_set_variable_list.go
+++ b/cmd/views/variable_set_variable_list.go
@@ -1,0 +1,59 @@
+// SPDX-License-Identifier: MIT
+// Copyright © 2025 Tom Straub <github.com/straubt1>
+
+package view
+
+import (
+	tfe "github.com/hashicorp/go-tfe"
+)
+
+// VariableSetVariableListView handles rendering for variable set variable list command
+type VariableSetVariableListView struct {
+	*BaseView
+}
+
+func NewVariableSetVariableListView() *VariableSetVariableListView {
+	return &VariableSetVariableListView{
+		BaseView: NewBaseView(),
+	}
+}
+
+// variableSetVariableListOutput is a JSON-safe representation of a variable set variable for list views
+type variableSetVariableListOutput struct {
+	ID        string `json:"id"`
+	Key       string `json:"key"`
+	Category  string `json:"category"`
+	Sensitive bool   `json:"sensitive"`
+	HCL       bool   `json:"hcl"`
+}
+
+// Render renders variables for a variable set
+func (v *VariableSetVariableListView) Render(variables []*tfe.VariableSetVariable) error {
+	if v.IsJSON() {
+		output := make([]variableSetVariableListOutput, len(variables))
+		for i, variable := range variables {
+			output[i] = variableSetVariableListOutput{
+				ID:        variable.ID,
+				Key:       variable.Key,
+				Category:  string(variable.Category),
+				Sensitive: variable.Sensitive,
+				HCL:       variable.HCL,
+			}
+		}
+		return v.Output().RenderJSON(output)
+	}
+
+	headers := []string{"Key", "ID", "Category", "Sensitive", "HCL"}
+	rows := make([][]interface{}, len(variables))
+	for i, variable := range variables {
+		rows[i] = []interface{}{
+			variable.Key,
+			variable.ID,
+			variable.Category,
+			variable.Sensitive,
+			variable.HCL,
+		}
+	}
+
+	return v.Output().RenderTable(headers, rows)
+}

--- a/cmd/views/variable_set_variable_show.go
+++ b/cmd/views/variable_set_variable_show.go
@@ -1,0 +1,64 @@
+// SPDX-License-Identifier: MIT
+// Copyright © 2025 Tom Straub <github.com/straubt1>
+
+package view
+
+import (
+	"fmt"
+
+	tfe "github.com/hashicorp/go-tfe"
+)
+
+// VariableSetVariableShowView handles rendering for variable set variable show command
+type VariableSetVariableShowView struct {
+	*BaseView
+}
+
+func NewVariableSetVariableShowView() *VariableSetVariableShowView {
+	return &VariableSetVariableShowView{
+		BaseView: NewBaseView(),
+	}
+}
+
+// variableSetVariableShowOutput is a JSON-safe representation of a variable set variable
+type variableSetVariableShowOutput struct {
+	ID          string `json:"id"`
+	Key         string `json:"key"`
+	Value       string `json:"value"`
+	Sensitive   bool   `json:"sensitive"`
+	HCL         bool   `json:"hcl"`
+	Category    string `json:"category"`
+	Description string `json:"description"`
+}
+
+// Render renders a single variable set variable's details
+func (v *VariableSetVariableShowView) Render(variable *tfe.VariableSetVariable) error {
+	if variable == nil {
+		return v.RenderError(fmt.Errorf("variable not found"))
+	}
+
+	if v.IsJSON() {
+		output := variableSetVariableShowOutput{
+			ID:          variable.ID,
+			Key:         variable.Key,
+			Value:       variable.Value,
+			Sensitive:   variable.Sensitive,
+			HCL:         variable.HCL,
+			Category:    string(variable.Category),
+			Description: variable.Description,
+		}
+		return v.Output().RenderJSON(output)
+	}
+
+	properties := []PropertyPair{
+		{Key: "ID", Value: variable.ID},
+		{Key: "Key", Value: variable.Key},
+		{Key: "Value", Value: variable.Value},
+		{Key: "Sensitive", Value: variable.Sensitive},
+		{Key: "HCL", Value: variable.HCL},
+		{Key: "Category", Value: variable.Category},
+		{Key: "Description", Value: variable.Description},
+	}
+
+	return v.Output().RenderProperties(properties)
+}

--- a/cmd/views/variable_set_variable_update.go
+++ b/cmd/views/variable_set_variable_update.go
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+// Copyright © 2025 Tom Straub <github.com/straubt1>
+
+package view
+
+import (
+	tfe "github.com/hashicorp/go-tfe"
+)
+
+// VariableSetVariableUpdateView handles rendering for variable set variable update command
+type VariableSetVariableUpdateView struct {
+	*BaseView
+}
+
+func NewVariableSetVariableUpdateView() *VariableSetVariableUpdateView {
+	return &VariableSetVariableUpdateView{
+		BaseView: NewBaseView(),
+	}
+}
+
+// Render renders an updated variable set variable's details
+func (v *VariableSetVariableUpdateView) Render(variable *tfe.VariableSetVariable) error {
+	if v.IsJSON() {
+		output := variableSetVariableShowOutput{
+			ID:          variable.ID,
+			Key:         variable.Key,
+			Value:       variable.Value,
+			Sensitive:   variable.Sensitive,
+			HCL:         variable.HCL,
+			Category:    string(variable.Category),
+			Description: variable.Description,
+		}
+		return v.Output().RenderJSON(output)
+	}
+
+	properties := []PropertyPair{
+		{Key: "ID", Value: variable.ID},
+		{Key: "Key", Value: variable.Key},
+		{Key: "Value", Value: variable.Value},
+		{Key: "Sensitive", Value: variable.Sensitive},
+		{Key: "HCL", Value: variable.HCL},
+		{Key: "Category", Value: variable.Category},
+		{Key: "Description", Value: variable.Description},
+	}
+
+	return v.Output().RenderProperties(properties)
+}

--- a/data/variable_set_variables.go
+++ b/data/variable_set_variables.go
@@ -1,0 +1,116 @@
+// Copyright (c) Tom Straub (github.com/straubt1) 2025
+// SPDX-License-Identifier: MIT
+
+package data
+
+import (
+	tfe "github.com/hashicorp/go-tfe"
+	"github.com/pkg/errors"
+	"github.com/straubt1/tfx/client"
+	"github.com/straubt1/tfx/output"
+)
+
+// FetchVariableSetVariables fetches all variables in a variable set using pagination.
+func FetchVariableSetVariables(c *client.TfxClient, variableSetID string) ([]*tfe.VariableSetVariable, error) {
+	output.Get().Logger().Debug("Fetching variable set variables", "variableSetID", variableSetID)
+
+	return client.FetchAll(c.Context, func(pageNumber int) ([]*tfe.VariableSetVariable, *client.Pagination, error) {
+		output.Get().Logger().Trace("Fetching variable set variables page", "variableSetID", variableSetID, "page", pageNumber)
+
+		opts := &tfe.VariableSetVariableListOptions{
+			ListOptions: tfe.ListOptions{PageNumber: pageNumber, PageSize: 100},
+		}
+
+		result, err := c.Client.VariableSetVariables.List(c.Context, variableSetID, opts)
+		if err != nil {
+			output.Get().Logger().Error("Failed to fetch variable set variables page", "variableSetID", variableSetID, "page", pageNumber, "error", err)
+			return nil, nil, err
+		}
+
+		output.Get().Logger().Trace("Variable set variables page fetched", "variableSetID", variableSetID, "page", pageNumber, "count", len(result.Items))
+		return result.Items, client.NewPaginationFromTFE(result.Pagination), nil
+	})
+}
+
+// FetchVariableSetVariable fetches a single variable by key in the specified variable set.
+func FetchVariableSetVariable(c *client.TfxClient, variableSetID string, key string) (*tfe.VariableSetVariable, error) {
+	output.Get().Logger().Debug("Fetching variable set variable by key", "variableSetID", variableSetID, "key", key)
+
+	variableID, err := GetVariableSetVariableID(c, variableSetID, key)
+	if err != nil {
+		output.Get().Logger().Error("Failed to get variable set variable ID", "variableSetID", variableSetID, "key", key, "error", err)
+		return nil, err
+	}
+
+	variable, err := c.Client.VariableSetVariables.Read(c.Context, variableSetID, variableID)
+	if err != nil {
+		output.Get().Logger().Error("Failed to fetch variable set variable", "variableSetID", variableSetID, "variableID", variableID, "error", err)
+		return nil, err
+	}
+
+	output.Get().Logger().Debug("Variable set variable fetched successfully", "variableSetID", variableSetID, "key", key, "variableID", variableID)
+	return variable, nil
+}
+
+// CreateVariableSetVariable creates a new variable in a variable set.
+func CreateVariableSetVariable(c *client.TfxClient, variableSetID string, opts tfe.VariableSetVariableCreateOptions) (*tfe.VariableSetVariable, error) {
+	output.Get().Logger().Debug("Creating variable set variable", "variableSetID", variableSetID, "key", *opts.Key)
+
+	variable, err := c.Client.VariableSetVariables.Create(c.Context, variableSetID, &opts)
+	if err != nil {
+		output.Get().Logger().Error("Failed to create variable set variable", "variableSetID", variableSetID, "key", *opts.Key, "error", err)
+		return nil, err
+	}
+
+	output.Get().Logger().Debug("Variable set variable created successfully", "variableSetID", variableSetID, "key", *opts.Key, "variableID", variable.ID)
+	return variable, nil
+}
+
+// UpdateVariableSetVariable updates an existing variable in a variable set.
+func UpdateVariableSetVariable(c *client.TfxClient, variableSetID, variableID string, opts tfe.VariableSetVariableUpdateOptions) (*tfe.VariableSetVariable, error) {
+	output.Get().Logger().Debug("Updating variable set variable", "variableSetID", variableSetID, "variableID", variableID)
+
+	variable, err := c.Client.VariableSetVariables.Update(c.Context, variableSetID, variableID, &opts)
+	if err != nil {
+		output.Get().Logger().Error("Failed to update variable set variable", "variableSetID", variableSetID, "variableID", variableID, "error", err)
+		return nil, err
+	}
+
+	output.Get().Logger().Debug("Variable set variable updated successfully", "variableSetID", variableSetID, "variableID", variableID)
+	return variable, nil
+}
+
+// DeleteVariableSetVariable deletes a variable from a variable set.
+func DeleteVariableSetVariable(c *client.TfxClient, variableSetID, variableID string) error {
+	output.Get().Logger().Debug("Deleting variable set variable", "variableSetID", variableSetID, "variableID", variableID)
+
+	err := c.Client.VariableSetVariables.Delete(c.Context, variableSetID, variableID)
+	if err != nil {
+		output.Get().Logger().Error("Failed to delete variable set variable", "variableSetID", variableSetID, "variableID", variableID, "error", err)
+		return err
+	}
+
+	output.Get().Logger().Debug("Variable set variable deleted successfully", "variableSetID", variableSetID, "variableID", variableID)
+	return nil
+}
+
+// GetVariableSetVariableID retrieves the variable ID from a variable set by variable key.
+func GetVariableSetVariableID(c *client.TfxClient, variableSetID string, key string) (string, error) {
+	output.Get().Logger().Debug("Getting variable set variable ID by key", "variableSetID", variableSetID, "key", key)
+
+	variables, err := FetchVariableSetVariables(c, variableSetID)
+	if err != nil {
+		output.Get().Logger().Error("Failed to fetch variable set variables", "variableSetID", variableSetID, "error", err)
+		return "", errors.Wrap(err, "failed to fetch variable set variables")
+	}
+
+	for _, v := range variables {
+		if v.Key == key {
+			output.Get().Logger().Debug("Variable set variable ID found", "variableSetID", variableSetID, "key", key, "variableID", v.ID)
+			return v.ID, nil
+		}
+	}
+
+	output.Get().Logger().Warn("Variable set variable key not found", "variableSetID", variableSetID, "key", key)
+	return "", errors.Errorf("variable with key %q not found in variable set %s", key, variableSetID)
+}

--- a/data/variable_sets.go
+++ b/data/variable_sets.go
@@ -5,25 +5,168 @@ package data
 
 import (
 	tfe "github.com/hashicorp/go-tfe"
+	"github.com/pkg/errors"
 	"github.com/straubt1/tfx/client"
 	"github.com/straubt1/tfx/output"
 )
+
+// VariableSetScope selects which variable sets to list or resolve.
+type VariableSetScope struct {
+	All              bool
+	OrganizationName string
+	ProjectName      string
+	WorkspaceName    string
+	Search           string
+}
+
+// VariableSetCreateParams holds options for creating a variable set.
+type VariableSetCreateParams struct {
+	Name, Description string
+	Global, Priority  bool
+	ProjectName       string // non-empty = project-owned (Parent.Project)
+	WorkspaceName     string // non-empty = ApplyToWorkspaces after create
+}
+
+func resolveVariableSetOrg(scope VariableSetScope, defaultOrg string) string {
+	if scope.OrganizationName != "" {
+		return scope.OrganizationName
+	}
+	return defaultOrg
+}
 
 // ListVariableSets lists all variable sets for an organization.
 func ListVariableSets(c *client.TfxClient, orgName string, search string) ([]*tfe.VariableSet, error) {
 	output.Get().Logger().Debug("Listing variable sets", "org", orgName, "search", search)
 
 	return client.FetchAll(c.Context, func(pageNumber int) ([]*tfe.VariableSet, *client.Pagination, error) {
+		output.Get().Logger().Trace("Listing variable sets page", "org", orgName, "page", pageNumber)
+
 		opts := &tfe.VariableSetListOptions{
 			ListOptions: tfe.ListOptions{PageNumber: pageNumber, PageSize: 100},
 			Query:       search,
 		}
 		res, err := c.Client.VariableSets.List(c.Context, orgName, opts)
 		if err != nil {
+			output.Get().Logger().Error("Failed to list variable sets page", "org", orgName, "page", pageNumber, "error", err)
 			return nil, nil, err
 		}
 		return res.Items, client.NewPaginationFromTFE(res.Pagination), nil
 	})
+}
+
+// ListVariableSetsWithScope lists variable sets according to the given scope.
+func ListVariableSetsWithScope(c *client.TfxClient, defaultOrg string, scope VariableSetScope) ([]*tfe.VariableSet, error) {
+	if scope.All {
+		output.Get().Logger().Debug("Listing variable sets across all organizations", "search", scope.Search)
+
+		orgs, err := FetchOrganizations(c, "")
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to list organizations")
+		}
+
+		var all []*tfe.VariableSet
+		for _, org := range orgs {
+			output.Get().Logger().Trace("Listing variable sets for organization", "org", org.Name)
+
+			sets, err := ListVariableSets(c, org.Name, scope.Search)
+			if err != nil {
+				return nil, errors.Wrapf(err, "failed to list variable sets for organization %s", org.Name)
+			}
+			all = append(all, sets...)
+		}
+		return all, nil
+	}
+
+	orgName := resolveVariableSetOrg(scope, defaultOrg)
+
+	if scope.WorkspaceName != "" {
+		return ListVariableSetsForWorkspace(c, orgName, scope.WorkspaceName, scope.Search)
+	}
+	if scope.ProjectName != "" {
+		return ListVariableSetsForProject(c, orgName, scope.ProjectName, scope.Search)
+	}
+
+	return ListVariableSets(c, orgName, scope.Search)
+}
+
+// ListVariableSetsForWorkspace lists variable sets applied to a workspace.
+func ListVariableSetsForWorkspace(c *client.TfxClient, orgName, workspaceName, search string) ([]*tfe.VariableSet, error) {
+	output.Get().Logger().Debug("Listing variable sets for workspace", "org", orgName, "workspace", workspaceName, "search", search)
+
+	workspaceID, err := GetWorkspaceID(c, orgName, workspaceName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to resolve workspace %q", workspaceName)
+	}
+
+	return client.FetchAll(c.Context, func(pageNumber int) ([]*tfe.VariableSet, *client.Pagination, error) {
+		output.Get().Logger().Trace("Listing variable sets for workspace page", "workspaceID", workspaceID, "page", pageNumber)
+
+		opts := &tfe.VariableSetListOptions{
+			ListOptions: tfe.ListOptions{PageNumber: pageNumber, PageSize: 100},
+			Query:       search,
+		}
+		res, err := c.Client.VariableSets.ListForWorkspace(c.Context, workspaceID, opts)
+		if err != nil {
+			output.Get().Logger().Error("Failed to list variable sets for workspace page", "workspaceID", workspaceID, "page", pageNumber, "error", err)
+			return nil, nil, err
+		}
+		return res.Items, client.NewPaginationFromTFE(res.Pagination), nil
+	})
+}
+
+// ListVariableSetsForProject lists variable sets applied to a project.
+func ListVariableSetsForProject(c *client.TfxClient, orgName, projectName, search string) ([]*tfe.VariableSet, error) {
+	output.Get().Logger().Debug("Listing variable sets for project", "org", orgName, "project", projectName, "search", search)
+
+	project, err := FetchProjectByName(c, orgName, projectName)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to resolve project %q", projectName)
+	}
+
+	return client.FetchAll(c.Context, func(pageNumber int) ([]*tfe.VariableSet, *client.Pagination, error) {
+		output.Get().Logger().Trace("Listing variable sets for project page", "projectID", project.ID, "page", pageNumber)
+
+		opts := &tfe.VariableSetListOptions{
+			ListOptions: tfe.ListOptions{PageNumber: pageNumber, PageSize: 100},
+			Query:       search,
+		}
+		res, err := c.Client.VariableSets.ListForProject(c.Context, project.ID, opts)
+		if err != nil {
+			output.Get().Logger().Error("Failed to list variable sets for project page", "projectID", project.ID, "page", pageNumber, "error", err)
+			return nil, nil, err
+		}
+		return res.Items, client.NewPaginationFromTFE(res.Pagination), nil
+	})
+}
+
+// GetVariableSetByName finds a variable set by exact name within the given scope.
+func GetVariableSetByName(c *client.TfxClient, orgName string, scope VariableSetScope, name string) (*tfe.VariableSet, error) {
+	output.Get().Logger().Debug("Getting variable set by name", "org", orgName, "name", name, "scope", scope)
+
+	sets, err := ListVariableSetsWithScope(c, orgName, scope)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to list variable sets")
+	}
+
+	for _, vs := range sets {
+		if vs.Name == name {
+			output.Get().Logger().Debug("Variable set found by name", "name", name, "id", vs.ID)
+			return vs, nil
+		}
+	}
+
+	return nil, errors.Errorf("variable set with name %q not found", name)
+}
+
+// ResolveVariableSet reads a variable set by ID or resolves it by name within the given scope.
+func ResolveVariableSet(c *client.TfxClient, defaultOrg string, scope VariableSetScope, name, id string) (*tfe.VariableSet, error) {
+	if id != "" {
+		return ReadVariableSet(c, id)
+	}
+	if name == "" {
+		return nil, errors.New("variable set name or id is required")
+	}
+	return GetVariableSetByName(c, defaultOrg, scope, name)
 }
 
 // ReadVariableSet reads a single variable set by ID, including its workspaces, projects, and variables.
@@ -41,15 +184,45 @@ func ReadVariableSet(c *client.TfxClient, variableSetID string) (*tfe.VariableSe
 }
 
 // CreateVariableSet creates a new variable set in the given organization.
-func CreateVariableSet(c *client.TfxClient, orgName, name, description string, global, priority bool) (*tfe.VariableSet, error) {
-	output.Get().Logger().Debug("Creating variable set", "org", orgName, "name", name)
+func CreateVariableSet(c *client.TfxClient, orgName string, params VariableSetCreateParams) (*tfe.VariableSet, error) {
+	output.Get().Logger().Debug("Creating variable set", "org", orgName, "name", params.Name)
 
-	return c.Client.VariableSets.Create(c.Context, orgName, &tfe.VariableSetCreateOptions{
-		Name:        &name,
-		Description: &description,
-		Global:      &global,
-		Priority:    &priority,
-	})
+	opts := &tfe.VariableSetCreateOptions{
+		Name:        &params.Name,
+		Description: &params.Description,
+		Global:      &params.Global,
+		Priority:    &params.Priority,
+	}
+
+	if params.ProjectName != "" {
+		project, err := FetchProjectByName(c, orgName, params.ProjectName)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to resolve project %q", params.ProjectName)
+		}
+		opts.Parent = &tfe.Parent{Project: project}
+	}
+
+	vs, err := c.Client.VariableSets.Create(c.Context, orgName, opts)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to create variable set")
+	}
+
+	if params.WorkspaceName != "" {
+		workspaceID, err := GetWorkspaceID(c, orgName, params.WorkspaceName)
+		if err != nil {
+			return nil, errors.Wrapf(err, "failed to resolve workspace %q", params.WorkspaceName)
+		}
+
+		err = c.Client.VariableSets.ApplyToWorkspaces(c.Context, vs.ID, &tfe.VariableSetApplyToWorkspacesOptions{
+			Workspaces: []*tfe.Workspace{{ID: workspaceID}},
+		})
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to apply variable set to workspace")
+		}
+	}
+
+	output.Get().Logger().Debug("Variable set created successfully", "org", orgName, "name", params.Name, "id", vs.ID)
+	return vs, nil
 }
 
 // DeleteVariableSet deletes a variable set by ID.

--- a/integration/README.md
+++ b/integration/README.md
@@ -18,6 +18,13 @@ export TEST_WORKSPACE_NAME="existing-workspace-name"
 # Optional: for project show tests (at least one required)
 export TEST_PROJECT_NAME="existing-project-name"
 export TEST_PROJECT_ID="prj-xxxxx"
+
+# Optional: profile-based varset lifecycle test (local.tfe.rocks)
+export TFX_INTEGRATION_PROFILE="local"
+# export TFX_CONFIG_FILE="$HOME/.tfx.hcl"  # when not using default paths
+
+# Optional: keep varsets/variables after TestVariableSetLocalProfileLifecycle (for manual inspection)
+export TFX_INTEGRATION_NO_CLEANUP=1
 ```
 
 ## Running Tests
@@ -52,6 +59,41 @@ go test -v -tags=integration -timeout 30s ./integration/...
 - [x] project list (with search filter)
 - [x] project show (by name)
 - [x] project show (by id)
+
+### Variable Set Commands
+
+- [x] variable-set list / CRUD (env-based credentials)
+- [x] variable-set lifecycle with `--profile local` (`TestVariableSetLocalProfileLifecycle`)
+
+## Profile-based local testing
+
+For a TFE instance at `local.tfe.rocks`, add a profile to `~/.tfx.hcl`:
+
+```hcl
+profile "local" {
+  hostname     = "local.tfe.rocks"
+  organization = "your-org"
+  token        = "your-token"
+}
+```
+
+Run the lifecycle test:
+
+```bash
+export TFX_INTEGRATION_PROFILE=local
+go test -v -tags=integration -count=1 ./integration/ -run TestVariableSetLocalProfileLifecycle
+```
+
+Optional: set `TEST_PROJECT_NAME` and/or `TEST_WORKSPACE_NAME` to also create project-owned and workspace-assigned variable sets in the same run.
+
+To leave created variable sets and variables in place (skip delete steps and `t.Cleanup`):
+
+```bash
+export TFX_INTEGRATION_NO_CLEANUP=1
+go test -v -tags=integration -count=1 ./integration/ -run TestVariableSetLocalProfileLifecycle
+```
+
+The test logs the search prefix and varset names so you can find them in the UI or with `tfx varset list --search <prefix>`.
 
 ## Notes
 

--- a/integration/README.md
+++ b/integration/README.md
@@ -97,7 +97,7 @@ The test logs the search prefix and varset names so you can find them in the UI 
 
 ## Notes
 
-- Tests use real API calls - they require valid credentials
-- Tests do not create/destroy resources (read-only operations)
-- Success criteria: command executes without error
+- Tests use real API calls — they require valid credentials
+- Most tests are read-only; `TestVariableSetLocalProfileLifecycle` creates and deletes variable sets (unless `TFX_INTEGRATION_NO_CLEANUP=1`)
+- Success criteria: command executes without error (non-zero exit on CLI failure)
 - Tests are skipped if required environment variables are not set

--- a/integration/petname.go
+++ b/integration/petname.go
@@ -1,0 +1,29 @@
+// Copyright (c) Tom Straub (github.com/straubt1) 2025
+// SPDX-License-Identifier: MIT
+
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"math/rand"
+	"time"
+)
+
+var petAdjectives = []string{
+	"amber", "brave", "calm", "daring", "eager", "fancy", "gentle", "happy",
+	"iconic", "jolly", "keen", "lively", "merry", "noble", "quick", "rusty",
+}
+
+var petNouns = []string{
+	"badger", "condor", "dragon", "eagle", "falcon", "gecko", "heron", "iguana",
+	"jaguar", "koala", "lemur", "marten", "newt", "otter", "panda", "quail",
+}
+
+// uniquePetName returns a random adjective-noun suffix for unique resource names.
+func uniquePetName() string {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
+	return fmt.Sprintf("%s-%s", petAdjectives[r.Intn(len(petAdjectives))], petNouns[r.Intn(len(petNouns))])
+}

--- a/integration/setup_test.go
+++ b/integration/setup_test.go
@@ -4,8 +4,6 @@
 //go:build integration
 // +build integration
 
-// Copyright © 2025 Tom Straub <github.com/straubt1>
-
 package integration
 
 import (
@@ -14,6 +12,8 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 	"github.com/straubt1/tfx/cmd"
 )
 
@@ -31,31 +31,64 @@ func setupTest(t *testing.T) (hostname, token, organization string) {
 	return hostname, token, organization
 }
 
-// executeCommand runs a tfx command with the given arguments and credentials
-// Returns error if command failed
-func executeCommand(t *testing.T, args []string, hostname, token, organization string) error {
-	// Get the root command
-	// Note: This requires exposing cmd.GetRootCommand() or using cmd.Execute directly
-	rootCmd := getRootCommand()
+const localIntegrationProfile = "local"
 
-	// Build full args with credentials
-	fullArgs := append([]string{
+// integrationSkipCleanup reports whether integration tests should leave created resources
+// in place. Set TFX_INTEGRATION_NO_CLEANUP=1 (or "true"/"yes") to skip delete steps
+// and t.Cleanup removal.
+func integrationSkipCleanup() bool {
+	switch os.Getenv("TFX_INTEGRATION_NO_CLEANUP") {
+	case "1", "true", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
+// setupProfileIntegrationTest skips unless TFX_INTEGRATION_PROFILE matches profileName.
+// Use with a ~/.tfx.hcl profile (e.g. "local" for local.tfe.rocks).
+func setupProfileIntegrationTest(t *testing.T, profileName string) {
+	t.Helper()
+	if os.Getenv("TFX_INTEGRATION_PROFILE") != profileName {
+		t.Skipf("Skipping profile integration test: set TFX_INTEGRATION_PROFILE=%q (requires profile %q in .tfx.hcl)", profileName, profileName)
+	}
+}
+
+// executeCommand runs a tfx command with the given arguments and credentials.
+func executeCommand(t *testing.T, args []string, hostname, token, organization string) error {
+	t.Helper()
+	prefix := []string{
 		"--hostname", hostname,
 		"--token", token,
 		"--organization", organization,
-	}, args...)
+	}
+	return runRootCommand(t, append(prefix, args...))
+}
 
-	rootCmd.SetArgs(fullArgs)
+// executeCommandWithProfile runs a tfx command using a named config profile.
+func executeCommandWithProfile(t *testing.T, profileName string, args []string) error {
+	t.Helper()
+	prefix := []string{"--profile", profileName}
+	if configFile := os.Getenv("TFX_CONFIG_FILE"); configFile != "" {
+		prefix = append(prefix, "--config-file", configFile)
+	}
+	return runRootCommand(t, append(prefix, args...))
+}
 
-	// Capture output for debugging
+func runRootCommand(t *testing.T, args []string) error {
+	t.Helper()
+	viper.Reset()
+
+	rootCmd := getRootCommand()
+	resetCommandFlags(rootCmd)
+	rootCmd.SetArgs(args)
+
 	var stdout, stderr bytes.Buffer
 	rootCmd.SetOut(&stdout)
 	rootCmd.SetErr(&stderr)
 
-	// Execute the command
 	err := rootCmd.Execute()
 
-	// Log output for debugging (visible with -v flag)
 	if stdout.Len() > 0 {
 		t.Logf("STDOUT:\n%s", stdout.String())
 	}
@@ -64,6 +97,16 @@ func executeCommand(t *testing.T, args []string, hostname, token, organization s
 	}
 
 	return err
+}
+
+func resetCommandFlags(cmd *cobra.Command) {
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		_ = f.Value.Set(f.DefValue)
+		f.Changed = false
+	})
+	for _, sub := range cmd.Commands() {
+		resetCommandFlags(sub)
+	}
 }
 
 // getRootCommand returns the root command for testing

--- a/integration/varset_local_test.go
+++ b/integration/varset_local_test.go
@@ -1,0 +1,328 @@
+// Copyright (c) Tom Straub (github.com/straubt1) 2025
+// SPDX-License-Identifier: MIT
+
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+type varsetFixture struct {
+	name       string
+	createArgs []string
+}
+
+type varsetVariableFixture struct {
+	varsetName string
+	key        string
+	deleteArgs []string
+}
+
+// TestVariableSetLocalProfileLifecycle exercises varset and variable CRUD against a
+// named TFX profile (local / local.tfe.rocks). Creates several variable sets with
+// mixed variable types, lists them, then deletes everything so end state matches start.
+//
+// Requires TFX_INTEGRATION_PROFILE=local and a matching profile block in ~/.tfx.hcl:
+//
+//	profile "local" {
+//	  hostname     = "local.tfe.rocks"
+//	  organization = "your-org"
+//	  token        = "..."
+//	}
+//
+// Set TFX_INTEGRATION_NO_CLEANUP=1 to skip delete steps and leave resources for inspection.
+func TestVariableSetLocalProfileLifecycle(t *testing.T) {
+	setupProfileIntegrationTest(t, localIntegrationProfile)
+
+	prefix := fmt.Sprintf("tfx-varset-%s", uniquePetName())
+	keyPrefix := strings.ReplaceAll(prefix, "-", "_")
+	profile := localIntegrationProfile
+
+	varsets := []varsetFixture{
+		{
+			name: prefix + "-org-a",
+			createArgs: []string{
+				"varset", "create",
+				"--name", prefix + "-org-a",
+				"--description", "TFx local integration test (org-owned A)",
+			},
+		},
+		{
+			name: prefix + "-org-b",
+			createArgs: []string{
+				"varset", "create",
+				"--name", prefix + "-org-b",
+				"--description", "TFx local integration test (org-owned B)",
+				"--priority",
+			},
+		},
+		{
+			name: prefix + "-org-c",
+			createArgs: []string{
+				"varset", "create",
+				"--name", prefix + "-org-c",
+				"--description", "TFx local integration test (org-owned C)",
+			},
+		},
+	}
+
+	if projectName := os.Getenv("TEST_PROJECT_NAME"); projectName != "" {
+		varsets = append(varsets, varsetFixture{
+			name: prefix + "-project",
+			createArgs: []string{
+				"varset", "create",
+				"--name", prefix + "-project",
+				"--description", "TFx local integration test (project-owned)",
+				"--project-name", projectName,
+			},
+		})
+	}
+
+	if workspaceName := os.Getenv("TEST_WORKSPACE_NAME"); workspaceName != "" {
+		varsets = append(varsets, varsetFixture{
+			name: prefix + "-workspace",
+			createArgs: []string{
+				"varset", "create",
+				"--name", prefix + "-workspace",
+				"--description", "TFx local integration test (workspace-assigned)",
+				"--workspace-name", workspaceName,
+			},
+		})
+	}
+
+	variables := []varsetVariableFixture{
+		{
+			varsetName: prefix + "-org-a",
+			key:        keyPrefix + "_tf_plain",
+			deleteArgs: []string{"varset", "variable", "delete", "--varset-name", prefix + "-org-a", "--key", keyPrefix + "_tf_plain"},
+		},
+		{
+			varsetName: prefix + "-org-a",
+			key:        keyPrefix + "_env_var",
+			deleteArgs: []string{"varset", "variable", "delete", "--varset-name", prefix + "-org-a", "--key", keyPrefix + "_env_var"},
+		},
+		{
+			varsetName: prefix + "-org-a",
+			key:        keyPrefix + "_hcl_var",
+			deleteArgs: []string{"varset", "variable", "delete", "--varset-name", prefix + "-org-a", "--key", keyPrefix + "_hcl_var"},
+		},
+		{
+			varsetName: prefix + "-org-a",
+			key:        keyPrefix + "_sensitive",
+			deleteArgs: []string{"varset", "variable", "delete", "--varset-name", prefix + "-org-a", "--key", keyPrefix + "_sensitive"},
+		},
+		{
+			varsetName: prefix + "-org-b",
+			key:        keyPrefix + "_b_tf",
+			deleteArgs: []string{"varset", "variable", "delete", "--varset-name", prefix + "-org-b", "--key", keyPrefix + "_b_tf"},
+		},
+		{
+			varsetName: prefix + "-org-b",
+			key:        keyPrefix + "_b_env",
+			deleteArgs: []string{"varset", "variable", "delete", "--varset-name", prefix + "-org-b", "--key", keyPrefix + "_b_env"},
+		},
+		{
+			varsetName: prefix + "-org-c",
+			key:        keyPrefix + "_c_tf",
+			deleteArgs: []string{"varset", "variable", "delete", "--varset-name", prefix + "-org-c", "--key", keyPrefix + "_c_tf"},
+		},
+	}
+
+	skipCleanup := integrationSkipCleanup()
+	if skipCleanup {
+		t.Logf("TFX_INTEGRATION_NO_CLEANUP set; resources will be left in place (search prefix %q)", prefix)
+	} else {
+		t.Cleanup(func() {
+			for _, v := range variables {
+				if err := executeCommandWithProfile(t, profile, v.deleteArgs); err != nil {
+					t.Logf("cleanup: delete variable %s in %s: %v", v.key, v.varsetName, err)
+				}
+			}
+			for i := len(varsets) - 1; i >= 0; i-- {
+				vs := varsets[i]
+				if err := executeCommandWithProfile(t, profile, []string{
+					"varset", "delete", "--name", vs.name,
+				}); err != nil {
+					t.Logf("cleanup: delete varset %s: %v", vs.name, err)
+				}
+			}
+		})
+	}
+
+	t.Run("create variable sets", func(t *testing.T) {
+		for _, vs := range varsets {
+			vs := vs
+			t.Run(vs.name, func(t *testing.T) {
+				if err := executeCommandWithProfile(t, profile, vs.createArgs); err != nil {
+					t.Fatalf("create variable set %s: %v", vs.name, err)
+				}
+			})
+		}
+	})
+
+	t.Run("create variables", func(t *testing.T) {
+		creates := []struct {
+			name string
+			args []string
+		}{
+			{
+				name: "terraform plain",
+				args: []string{
+					"varset", "variable", "create",
+					"--varset-name", prefix + "-org-a",
+					"--key", keyPrefix + "_tf_plain",
+					"--value", "plain-value",
+					"--description", "terraform category",
+				},
+			},
+			{
+				name: "environment",
+				args: []string{
+					"varset", "variable", "create",
+					"--varset-name", prefix + "-org-a",
+					"--key", keyPrefix + "_env_var",
+					"--value", "env-value",
+					"--env",
+					"--description", "environment category",
+				},
+			},
+			{
+				name: "hcl",
+				args: []string{
+					"varset", "variable", "create",
+					"--varset-name", prefix + "-org-a",
+					"--key", keyPrefix + "_hcl_var",
+					"--value", `{"region"="us-east-1"}`,
+					"--hcl",
+					"--description", "hcl category",
+				},
+			},
+			{
+				name: "sensitive",
+				args: []string{
+					"varset", "variable", "create",
+					"--varset-name", prefix + "-org-a",
+					"--key", keyPrefix + "_sensitive",
+					"--value", "super-secret",
+					"--sensitive",
+					"--description", "sensitive variable",
+				},
+			},
+			{
+				name: "org-b terraform",
+				args: []string{
+					"varset", "variable", "create",
+					"--varset-name", prefix + "-org-b",
+					"--key", keyPrefix + "_b_tf",
+					"--value", "beta-tf",
+				},
+			},
+			{
+				name: "org-b environment",
+				args: []string{
+					"varset", "variable", "create",
+					"--varset-name", prefix + "-org-b",
+					"--key", keyPrefix + "_b_env",
+					"--value", "beta-env",
+					"--env",
+				},
+			},
+			{
+				name: "org-c terraform",
+				args: []string{
+					"varset", "variable", "create",
+					"--varset-name", prefix + "-org-c",
+					"--key", keyPrefix + "_c_tf",
+					"--value", "gamma-tf",
+				},
+			},
+		}
+
+		for _, tc := range creates {
+			tc := tc
+			t.Run(tc.name, func(t *testing.T) {
+				if err := executeCommandWithProfile(t, profile, tc.args); err != nil {
+					t.Fatalf("create variable (%s): %v", tc.name, err)
+				}
+			})
+		}
+	})
+
+	t.Run("list variable sets by search prefix", func(t *testing.T) {
+		if err := executeCommandWithProfile(t, profile, []string{
+			"varset", "list", "--search", prefix,
+		}); err != nil {
+			t.Fatalf("list variable sets: %v", err)
+		}
+	})
+
+	t.Run("list variables in primary varset", func(t *testing.T) {
+		if err := executeCommandWithProfile(t, profile, []string{
+			"varset", "variable", "list", "--varset-name", prefix + "-org-a",
+		}); err != nil {
+			t.Fatalf("list variables: %v", err)
+		}
+	})
+
+	t.Run("show variable set by name", func(t *testing.T) {
+		if err := executeCommandWithProfile(t, profile, []string{
+			"varset", "show", "--name", prefix + "-org-a",
+		}); err != nil {
+			t.Fatalf("show variable set: %v", err)
+		}
+	})
+
+	if skipCleanup {
+		t.Run("list retained varsets", func(t *testing.T) {
+			for _, vs := range varsets {
+				t.Logf("retained varset: %s", vs.name)
+			}
+			if err := executeCommandWithProfile(t, profile, []string{
+				"varset", "list", "--search", prefix,
+			}); err != nil {
+				t.Fatalf("list retained varsets: %v", err)
+			}
+		})
+	} else {
+		t.Run("delete variables", func(t *testing.T) {
+			for _, v := range variables {
+				v := v
+				t.Run(v.key, func(t *testing.T) {
+					if err := executeCommandWithProfile(t, profile, v.deleteArgs); err != nil {
+						t.Fatalf("delete variable %s: %v", v.key, err)
+					}
+				})
+			}
+			// Clear cleanup list so t.Cleanup does not retry successful deletes.
+			variables = nil
+		})
+
+		t.Run("delete variable sets", func(t *testing.T) {
+			for _, vs := range varsets {
+				vs := vs
+				t.Run(vs.name, func(t *testing.T) {
+					if err := executeCommandWithProfile(t, profile, []string{
+						"varset", "delete", "--name", vs.name,
+					}); err != nil {
+						t.Fatalf("delete variable set %s: %v", vs.name, err)
+					}
+				})
+			}
+			varsets = nil
+		})
+
+		t.Run("verify no leftover varsets for prefix", func(t *testing.T) {
+			if err := executeCommandWithProfile(t, profile, []string{
+				"varset", "list", "--search", prefix,
+			}); err != nil {
+				t.Fatalf("list after cleanup: %v", err)
+			}
+		})
+	}
+}

--- a/integration/varset_test.go
+++ b/integration/varset_test.go
@@ -11,6 +11,11 @@ import (
 	"testing"
 )
 
+const (
+	integrationVarsetName = "tfx-integration-test-varset"
+	integrationVarKey    = "tfx-integration-test-key"
+)
+
 func TestVariableSetList(t *testing.T) {
 	hostname, token, org := setupTest(t)
 
@@ -30,6 +35,10 @@ func TestVariableSetList(t *testing.T) {
 			name: "list variable sets via alias",
 			args: []string{"varset", "list"},
 		},
+		{
+			name: "list variable sets across all organizations",
+			args: []string{"varset", "list", "--all"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -40,16 +49,48 @@ func TestVariableSetList(t *testing.T) {
 			}
 		})
 	}
+
+	testProjectName := os.Getenv("TEST_PROJECT_NAME")
+	if testProjectName != "" {
+		t.Run("list variable sets for project", func(t *testing.T) {
+			err := executeCommand(t,
+				[]string{"varset", "list", "--project-name", testProjectName},
+				hostname, token, org,
+			)
+			if err != nil {
+				t.Errorf("Command failed: %v", err)
+			}
+		})
+	} else {
+		t.Run("list variable sets for project", func(t *testing.T) {
+			t.Skip("TEST_PROJECT_NAME not set — skipping project-scoped list test")
+		})
+	}
+
+	testWorkspaceName := os.Getenv("TEST_WORKSPACE_NAME")
+	if testWorkspaceName != "" {
+		t.Run("list variable sets for workspace", func(t *testing.T) {
+			err := executeCommand(t,
+				[]string{"varset", "list", "--workspace-name", testWorkspaceName},
+				hostname, token, org,
+			)
+			if err != nil {
+				t.Errorf("Command failed: %v", err)
+			}
+		})
+	} else {
+		t.Run("list variable sets for workspace", func(t *testing.T) {
+			t.Skip("TEST_WORKSPACE_NAME not set — skipping workspace-scoped list test")
+		})
+	}
 }
 
 func TestVariableSetCRUD(t *testing.T) {
 	hostname, token, org := setupTest(t)
 
-	// Create
-	var createdID string
 	t.Run("create variable set", func(t *testing.T) {
 		err := executeCommand(t,
-			[]string{"variable-set", "create", "--name", "tfx-integration-test-varset", "--description", "Created by TFx integration test"},
+			[]string{"variable-set", "create", "--name", integrationVarsetName, "--description", "Created by TFx integration test"},
 			hostname, token, org,
 		)
 		if err != nil {
@@ -57,10 +98,9 @@ func TestVariableSetCRUD(t *testing.T) {
 		}
 	})
 
-	// List to get ID
 	t.Run("list variable sets after create", func(t *testing.T) {
 		err := executeCommand(t,
-			[]string{"variable-set", "list", "--search", "tfx-integration-test-varset"},
+			[]string{"variable-set", "list", "--search", integrationVarsetName},
 			hostname, token, org,
 		)
 		if err != nil {
@@ -68,33 +108,89 @@ func TestVariableSetCRUD(t *testing.T) {
 		}
 	})
 
-	// Show (only if TEST_VARSET_ID is provided)
-	testVarSetID := os.Getenv("TEST_VARSET_ID")
-	if testVarSetID != "" {
-		createdID = testVarSetID
-		t.Run("show variable set", func(t *testing.T) {
-			err := executeCommand(t,
-				[]string{"variable-set", "show", "--id", createdID},
-				hostname, token, org,
-			)
-			if err != nil {
-				t.Errorf("show variable set failed: %v", err)
-			}
-		})
+	t.Run("show variable set by name", func(t *testing.T) {
+		err := executeCommand(t,
+			[]string{"varset", "show", "--name", integrationVarsetName},
+			hostname, token, org,
+		)
+		if err != nil {
+			t.Errorf("show variable set by name failed: %v", err)
+		}
+	})
 
-		// Delete
-		t.Run("delete variable set", func(t *testing.T) {
-			err := executeCommand(t,
-				[]string{"variable-set", "delete", "--id", createdID},
-				hostname, token, org,
-			)
-			if err != nil {
-				t.Errorf("delete variable set failed: %v", err)
-			}
-		})
-	} else {
-		t.Log("TEST_VARSET_ID not set — skipping show and delete tests. Set TEST_VARSET_ID to the ID of a variable set to test these.")
-	}
+	t.Run("delete variable set by name", func(t *testing.T) {
+		err := executeCommand(t,
+			[]string{"varset", "delete", "--name", integrationVarsetName},
+			hostname, token, org,
+		)
+		if err != nil {
+			t.Errorf("delete variable set by name failed: %v", err)
+		}
+	})
+}
+
+func TestVariableSetVariableCRUD(t *testing.T) {
+	hostname, token, org := setupTest(t)
+
+	t.Run("create variable set", func(t *testing.T) {
+		err := executeCommand(t,
+			[]string{"varset", "create", "--name", integrationVarsetName, "--description", "Created by TFx integration test"},
+			hostname, token, org,
+		)
+		if err != nil {
+			t.Fatalf("create variable set failed: %v", err)
+		}
+	})
+
+	t.Run("create variable in variable set", func(t *testing.T) {
+		err := executeCommand(t,
+			[]string{
+				"varset", "variable", "create",
+				"--varset-name", integrationVarsetName,
+				"--key", integrationVarKey,
+				"--value", "integration-test",
+				"--description", "Created by TFx integration test",
+			},
+			hostname, token, org,
+		)
+		if err != nil {
+			t.Fatalf("create variable failed: %v", err)
+		}
+	})
+
+	t.Run("list variables in variable set", func(t *testing.T) {
+		err := executeCommand(t,
+			[]string{"varset", "variable", "list", "--varset-name", integrationVarsetName},
+			hostname, token, org,
+		)
+		if err != nil {
+			t.Errorf("list variables failed: %v", err)
+		}
+	})
+
+	t.Run("delete variable from variable set", func(t *testing.T) {
+		err := executeCommand(t,
+			[]string{
+				"varset", "variable", "delete",
+				"--varset-name", integrationVarsetName,
+				"--key", integrationVarKey,
+			},
+			hostname, token, org,
+		)
+		if err != nil {
+			t.Errorf("delete variable failed: %v", err)
+		}
+	})
+
+	t.Run("delete variable set", func(t *testing.T) {
+		err := executeCommand(t,
+			[]string{"varset", "delete", "--name", integrationVarsetName},
+			hostname, token, org,
+		)
+		if err != nil {
+			t.Errorf("delete variable set failed: %v", err)
+		}
+	})
 }
 
 func TestVariableSetShow(t *testing.T) {

--- a/site/src/content/docs/commands/variable_set.md
+++ b/site/src/content/docs/commands/variable_set.md
@@ -2,24 +2,53 @@
 title: Variable Set Commands
 ---
 
-General commands to manage Variable Sets.
+General commands to manage Variable Sets and their variables.
 
 :::note
-All commands below can be used with a `varset` alias.
+All commands below can be used with a `varset` alias. Variable subcommands also accept a `var` alias (`tfx varset var`).
 :::
+
+## Ownership vs assignment
+
+Variable sets have two independent concepts:
+
+| Concept | What it means | How to set it |
+|---|---|---|
+| **Ownership** | Who owns the variable set (organization or project) | Default create = org-owned. Use `--project-name` on create for a project-owned set. |
+| **Assignment** | Where the variable set applies (workspaces/projects) | `--global` applies to all workspaces in the org. `--workspace-name` on create applies to one workspace after creation. Project/workspace list scopes show sets *assigned* to that target. |
+
+Ownership and assignment are separate: an org-owned set can be assigned to specific workspaces; a project-owned set is owned by a project but may still be assigned elsewhere via the API.
+
+### Scope flags (list, show, delete, and variable commands)
+
+These flags select which variable sets to list or how to resolve a variable set by name:
+
+| Flag | Used by | Description |
+|---|---|---|
+| `--organization-name` | list, show, delete, variable | Organization to use (defaults to configured organization). |
+| `--project-name` | list, show, delete, variable | List sets assigned to a project, or narrow name lookup to that project scope. |
+| `--workspace-name` | list, show, delete, variable | List sets assigned to a workspace, or narrow name lookup to that workspace scope. |
+| `--all` / `-a` | list only | List variable sets across all organizations you can access. |
+| `--search` / `-s` | list only | Filter results by variable set name (composes with any list scope). |
 
 ## `tfx variable-set list`
 
-List Variable Sets available for a given Organization.
+List variable sets. Default scope is the configured organization. Use scope flags to list by project, workspace, or all organizations.
 
-Using the `--search` flag allows filtering by variable set name with a given string.
+| Flag | Description |
+|---|---|
+| `--search` / `-s` | Filter by variable set name (optional). |
+| `--all` / `-a` | List across all organizations (mutually exclusive with `--project-name` and `--workspace-name`). |
+| `--organization-name` | Organization to list (optional, defaults to configured org). |
+| `--project-name` | List variable sets assigned to this project (optional). |
+| `--workspace-name` | List variable sets assigned to this workspace (optional). |
 
-**Basic Example**
+**Organization Example (default)**
 
 ```sh
-$ tfx variable-set list
+$ tfx varset list
 Using config file: /Users/tstraub/.tfx.hcl
-List Variable Sets for Organization: firefly
+Listing variable sets in organization 'firefly'
 ╭──────────────────────┬─────────────────────┬────────┬──────────┬───────────────────────────────╮
 │ NAME                 │ ID                  │ GLOBAL │ PRIORITY │ PARENT                        │
 ├──────────────────────┼─────────────────────┼────────┼──────────┼───────────────────────────────┤
@@ -32,9 +61,9 @@ List Variable Sets for Organization: firefly
 **Search Example**
 
 ```sh
-$ tfx variable-set list --search aws
+$ tfx varset list --search aws
 Using config file: /Users/tstraub/.tfx.hcl
-List Variable Sets for Organization: firefly
+Listing variable sets in organization 'firefly' matching 'aws'
 ╭─────────────────┬─────────────────────┬────────┬──────────┬──────────────────────╮
 │ NAME            │ ID                  │ GLOBAL │ PRIORITY │ PARENT               │
 ├─────────────────┼─────────────────────┼────────┼──────────┼──────────────────────┤
@@ -42,31 +71,64 @@ List Variable Sets for Organization: firefly
 ╰─────────────────┴─────────────────────┴────────┴──────────┴──────────────────────╯
 ```
 
-**Alias Example**
+**Project-scoped Example**
 
 ```sh
-$ tfx varset list
+$ tfx varset list --project-name my-project
 Using config file: /Users/tstraub/.tfx.hcl
-List Variable Sets for Organization: firefly
-╭──────────────────────┬─────────────────────┬────────┬──────────┬───────────────────────────────╮
-│ NAME                 │ ID                  │ GLOBAL │ PRIORITY │ PARENT                        │
-├──────────────────────┼─────────────────────┼────────┼──────────┼───────────────────────────────┤
-│ aws-credentials      │ varset-abc123XYZ456 │ false  │ false    │ organization:firefly          │
-│ common-tags          │ varset-def789GHI012 │ true   │ false    │ organization:firefly          │
-│ production-overrides │ varset-jkl345MNO678 │ false  │ true     │ project:prj-ABC123defGHI789   │
-╰──────────────────────┴─────────────────────┴────────┴──────────┴───────────────────────────────╯
+Listing variable sets for project 'my-project' in organization 'firefly'
+╭──────────────────────┬─────────────────────┬────────┬──────────┬─────────────────────────────╮
+│ NAME                 │ ID                  │ GLOBAL │ PRIORITY │ PARENT                      │
+├──────────────────────┼─────────────────────┼────────┼──────────┼─────────────────────────────┤
+│ production-overrides │ varset-jkl345MNO678 │ false  │ true     │ project:prj-ABC123defGHI789 │
+╰──────────────────────┴─────────────────────┴────────┴──────────┴─────────────────────────────╯
+```
+
+**Workspace-scoped Example**
+
+```sh
+$ tfx varset list --workspace-name prod-us-east-1
+Using config file: /Users/tstraub/.tfx.hcl
+Listing variable sets for workspace 'prod-us-east-1' in organization 'firefly'
+╭─────────────────┬─────────────────────┬────────┬──────────┬──────────────────────╮
+│ NAME            │ ID                  │ GLOBAL │ PRIORITY │ PARENT               │
+├─────────────────┼─────────────────────┼────────┼──────────┼──────────────────────┤
+│ aws-credentials │ varset-abc123XYZ456 │ false  │ false    │ organization:firefly │
+╰─────────────────┴─────────────────────┴────────┴──────────┴──────────────────────╯
+```
+
+**All Organizations Example**
+
+```sh
+$ tfx varset list --all
+Using config file: /Users/tstraub/.tfx.hcl
+Listing variable sets across all organizations
+╭──────────────┬─────────────────┬─────────────────────┬────────┬──────────┬──────────────────────╮
+│ ORGANIZATION │ NAME            │ ID                  │ GLOBAL │ PRIORITY │ PARENT               │
+├──────────────┼─────────────────┼─────────────────────┼────────┼──────────┼──────────────────────┤
+│ firefly      │ aws-credentials │ varset-abc123XYZ456 │ false  │ false    │ organization:firefly │
+│ staging      │ common-tags     │ varset-def789GHI012 │ true   │ false    │ organization:staging │
+╰──────────────┴─────────────────┴─────────────────────┴────────┴──────────┴──────────────────────╯
 ```
 
 ## `tfx variable-set show`
 
-Show details of a given Variable Set by ID, including assigned workspaces, projects, and variables.
+Show details of a variable set by ID or name, including assigned workspaces, projects, and variables. When using `--name`, scope flags help resolve the correct set when names are ambiguous.
 
-**Example**
+| Flag | Description | Required |
+|---|---|---|
+| `--id` / `-i` | ID of the variable set | One of `--id` or `--name` |
+| `--name` / `-n` | Name of the variable set | One of `--id` or `--name` |
+| `--organization-name` | Organization scope (optional). | No |
+| `--project-name` | Project scope for name resolution (optional). | No |
+| `--workspace-name` | Workspace scope for name resolution (optional). | No |
+
+**Example (by ID)**
 
 ```sh
 $ tfx variable-set show -i varset-abc123XYZ456
 Using config file: /Users/tstraub/.tfx.hcl
-Show Variable Set: varset-abc123XYZ456
+Showing variable set 'varset-abc123XYZ456'
 ID:          varset-abc123XYZ456
 Name:        aws-credentials
 Description: AWS credentials for production workloads
@@ -80,6 +142,17 @@ Projects:
 Variables:
   AWS_ACCESS_KEY_ID:     var-GHI789jklMNO345
   AWS_SECRET_ACCESS_KEY: var-JKL012mnoPQR678
+```
+
+**Example (by name)**
+
+```sh
+$ tfx varset show --name aws-credentials
+Using config file: /Users/tstraub/.tfx.hcl
+Showing variable set 'aws-credentials'
+ID:          varset-abc123XYZ456
+Name:        aws-credentials
+...
 ```
 
 **JSON Example**
@@ -110,21 +183,24 @@ $ tfx variable-set show -i varset-abc123XYZ456 --json | jq .
 
 ## `tfx variable-set create`
 
-Create a new Variable Set in the Organization.
+Create a new variable set. Default ownership is the configured organization.
 
 | Flag | Description | Required |
 |---|---|---|
-| `--name` / `-n` | Name of the Variable Set | Yes |
-| `--description` / `-d` | Description of the Variable Set | No |
-| `--global` | Apply this Variable Set to all workspaces in the organization | No |
+| `--name` / `-n` | Name of the variable set | Yes |
+| `--description` / `-d` | Description of the variable set | No |
+| `--global` | Apply this variable set to all workspaces in the organization | No |
 | `--priority` | Variable values in this set override workspace-level values | No |
+| `--organization-name` | Organization to create in (defaults to configured org) | No |
+| `--project-name` | Create as a project-owned variable set (mutually exclusive with `--global`) | No |
+| `--workspace-name` | Apply the variable set to this workspace after creation | No |
 
-**Basic Example**
+**Basic Example (org-owned)**
 
 ```sh
 $ tfx variable-set create --name aws-credentials --description "AWS credentials for production workloads"
 Using config file: /Users/tstraub/.tfx.hcl
-Create Variable Set for Organization: firefly
+Creating variable set 'aws-credentials' in organization 'firefly'
 ID:          varset-abc123XYZ456
 Name:        aws-credentials
 Description: AWS credentials for production workloads
@@ -137,7 +213,7 @@ Priority:    false
 ```sh
 $ tfx variable-set create --name common-tags --description "Tags applied to all workspaces" --global
 Using config file: /Users/tstraub/.tfx.hcl
-Create Variable Set for Organization: firefly
+Creating variable set 'common-tags' in organization 'firefly'
 ID:          varset-def789GHI012
 Name:        common-tags
 Description: Tags applied to all workspaces
@@ -145,33 +221,165 @@ Global:      true
 Priority:    false
 ```
 
-**Priority Variable Set Example**
+**Project-owned Example**
 
 ```sh
-$ tfx variable-set create --name production-overrides --description "Overrides for production runs" --priority
+$ tfx varset create --name project-vars --project-name my-project --description "Owned by my-project"
 Using config file: /Users/tstraub/.tfx.hcl
-Create Variable Set for Organization: firefly
-ID:          varset-jkl345MNO678
-Name:        production-overrides
-Description: Overrides for production runs
+Creating variable set 'project-vars' in organization 'firefly'
+ID:          varset-mno345PQR678
+Name:        project-vars
+Description: Owned by my-project
 Global:      false
-Priority:    true
+Priority:    false
+Parent:      project:prj-ABC123defGHI789
+```
+
+**Workspace Assignment Example**
+
+```sh
+$ tfx varset create --name ws-overrides --workspace-name prod-us-east-1 --description "Applied to prod-us-east-1"
+Using config file: /Users/tstraub/.tfx.hcl
+Creating variable set 'ws-overrides' in organization 'firefly'
+ID:          varset-pqr678STU901
+Name:        ws-overrides
+Description: Applied to prod-us-east-1
+Global:      false
+Priority:    false
 ```
 
 ## `tfx variable-set delete`
 
-Delete a Variable Set by ID.
+Delete a variable set by ID or name. Scope flags apply when using `--name`.
+
+| Flag | Description | Required |
+|---|---|---|
+| `--id` / `-i` | ID of the variable set to delete | One of `--id` or `--name` |
+| `--name` / `-n` | Name of the variable set to delete | One of `--id` or `--name` |
+| `--organization-name` | Organization scope (optional). | No |
+| `--project-name` | Project scope for name resolution (optional). | No |
+| `--workspace-name` | Workspace scope for name resolution (optional). | No |
 
 :::caution
-This will permanently delete the Variable Set and remove it from all workspaces and projects it is currently assigned to.
+This permanently deletes the variable set and removes it from all workspaces and projects it is assigned to.
 :::
 
-**Example**
+**Example (by ID)**
 
 ```sh
 $ tfx variable-set delete -i varset-abc123XYZ456
 Using config file: /Users/tstraub/.tfx.hcl
-Delete Variable Set: varset-abc123XYZ456
+Deleting variable set 'varset-abc123XYZ456'
 Status: Success
 ID:     varset-abc123XYZ456
+```
+
+**Example (by name)**
+
+```sh
+$ tfx varset delete --name aws-credentials
+Using config file: /Users/tstraub/.tfx.hcl
+Deleting variable set 'aws-credentials'
+Status: Success
+ID:     varset-abc123XYZ456
+```
+
+## `tfx variable-set variable`
+
+Manage variables within a variable set. All subcommands require `--varset-id` or `--varset-name` (mutually exclusive). When using `--varset-name`, scope flags narrow lookup the same way as show/delete.
+
+Common flags for every variable subcommand:
+
+| Flag | Description |
+|---|---|
+| `--varset-id` | ID of the variable set |
+| `--varset-name` | Name of the variable set |
+| `--organization-name` | Organization scope (optional). |
+| `--project-name` | Project scope for varset name resolution (optional). |
+| `--workspace-name` | Workspace scope for varset name resolution (optional). |
+
+### `tfx varset variable list`
+
+List variables in a variable set.
+
+```sh
+$ tfx varset variable list --varset-name aws-credentials
+Using config file: /Users/tstraub/.tfx.hcl
+Listing variables for variable set 'aws-credentials'
+╭───────────────────────┬─────────────────────┬───────────┬───────────┬───────╮
+│ KEY                   │ ID                  │ CATEGORY  │ SENSITIVE │ HCL   │
+├───────────────────────┼─────────────────────┼───────────┼───────────┼───────┤
+│ AWS_ACCESS_KEY_ID     │ var-GHI789jklMNO345 │ terraform │ false     │ false │
+│ AWS_SECRET_ACCESS_KEY │ var-JKL012mnoPQR678 │ terraform │ true      │ false │
+╰───────────────────────┴─────────────────────┴───────────┴───────────┴───────╯
+```
+
+### `tfx varset variable create`
+
+Create a variable in a variable set.
+
+| Flag | Description | Required |
+|---|---|---|
+| `--key` / `-k` | Variable key | Yes |
+| `--value` / `-v` | Variable value | One of `--value` or `--value-file` |
+| `--value-file` / `-f` | Read value from file | One of `--value` or `--value-file` |
+| `--description` / `-d` | Description | No |
+| `--env` / `-e` | Environment variable (default: Terraform variable) | No |
+| `--hcl` | Value is HCL | No |
+| `--sensitive` / `-s` | Sensitive variable | No |
+
+```sh
+$ tfx varset variable create --varset-name aws-credentials -k AWS_REGION -v us-east-1 -d "Default AWS region"
+Using config file: /Users/tstraub/.tfx.hcl
+Creating variable 'AWS_REGION' for variable set 'aws-credentials'
+ID:          var-XYZ789abcDEF012
+Key:         AWS_REGION
+Value:       us-east-1
+Sensitive:   false
+HCL:         false
+Category:    terraform
+Description: Default AWS region
+```
+
+### `tfx varset variable show`
+
+Show a single variable by key.
+
+```sh
+$ tfx varset variable show --varset-name aws-credentials -k AWS_REGION
+Using config file: /Users/tstraub/.tfx.hcl
+Showing variable 'AWS_REGION' for variable set 'aws-credentials'
+ID:          var-XYZ789abcDEF012
+Key:         AWS_REGION
+Value:       us-east-1
+Sensitive:   false
+HCL:         false
+Category:    terraform
+Description: Default AWS region
+```
+
+### `tfx varset variable update`
+
+Update a variable by key. Same flags as create.
+
+```sh
+$ tfx varset variable update --varset-name aws-credentials -k AWS_REGION -v us-west-2
+Using config file: /Users/tstraub/.tfx.hcl
+Updating variable 'AWS_REGION' for variable set 'aws-credentials'
+ID:          var-XYZ789abcDEF012
+Key:         AWS_REGION
+Value:       us-west-2
+...
+```
+
+### `tfx varset variable delete`
+
+Delete a variable by key.
+
+```sh
+$ tfx varset variable delete --varset-name aws-credentials -k AWS_REGION
+Using config file: /Users/tstraub/.tfx.hcl
+Deleting variable 'AWS_REGION' for variable set 'aws-credentials'
+Status: Success
+Key:    AWS_REGION
 ```

--- a/site/src/content/docs/commands/variable_set.md
+++ b/site/src/content/docs/commands/variable_set.md
@@ -328,6 +328,8 @@ Create a variable in a variable set.
 | `--hcl` | Value is HCL | No |
 | `--sensitive` / `-s` | Sensitive variable | No |
 
+Environment variable keys (`--env`) must begin with a letter or underscore and contain only letters, numbers, and underscores (no hyphens).
+
 ```sh
 $ tfx varset variable create --varset-name aws-credentials -k AWS_REGION -v us-east-1 -d "Default AWS region"
 Using config file: /Users/tstraub/.tfx.hcl

--- a/site/src/content/docs/testing/test_plan.md
+++ b/site/src/content/docs/testing/test_plan.md
@@ -889,11 +889,127 @@ tfx admin terraform-version delete --version 1.9.9
 
 ---
 
+## Variable Sets
+
+Use a unique prefix in variable set names (e.g. `tfx-test-<date>`) so cleanup is easy to identify.
+
+### 84. List Variable Sets (organization scope)
+
+```sh
+tfx varset list
+```
+
+**Expected:** Table of variable sets with `NAME`, `ID`, `GLOBAL`, `PRIORITY`, and `PARENT` columns.
+
+### 85. List Variable Sets (search)
+
+```sh
+tfx varset list --search aws
+```
+
+**Expected:** Filtered list matching the search term.
+
+### 86. List Variable Sets (project scope)
+
+```sh
+tfx varset list --project-name <project-name>
+```
+
+**Expected:** Variable sets assigned to the named project.
+
+### 87. Create an Organization-Owned Variable Set
+
+```sh
+tfx varset create \
+  --name tfx-test-varset \
+  --description "TFx test plan variable set"
+```
+
+**Expected:** Confirmation with variable set ID. Record the name for later steps.
+
+### 88. Show Variable Set by Name
+
+```sh
+tfx varset show --name tfx-test-varset
+```
+
+**Expected:** Detail view including parent, workspaces, projects, and variables (empty initially).
+
+### 89. Create a Terraform Variable in the Set
+
+```sh
+tfx varset variable create \
+  --varset-name tfx-test-varset \
+  --key TFX_TEST_REGION \
+  --value us-east-1 \
+  --description "Test terraform variable"
+```
+
+**Expected:** Confirmation showing `Category: terraform`.
+
+### 90. Create an Environment Variable in the Set
+
+```sh
+tfx varset variable create \
+  --varset-name tfx-test-varset \
+  --key TFX_TEST_ENV \
+  --value test-value \
+  --env
+```
+
+**Expected:** Confirmation showing `Category: env`. Keys for environment variables must use letters, numbers, and underscores only (no hyphens).
+
+### 91. List Variables in the Set
+
+```sh
+tfx varset variable list --varset-name tfx-test-varset
+```
+
+**Expected:** Table showing both variables created above.
+
+### 92. Show a Variable
+
+```sh
+tfx varset variable show --varset-name tfx-test-varset --key TFX_TEST_REGION
+```
+
+**Expected:** Detail view for the variable.
+
+### 93. Update a Variable
+
+```sh
+tfx varset variable update \
+  --varset-name tfx-test-varset \
+  --key TFX_TEST_REGION \
+  --value us-west-2
+```
+
+**Expected:** Confirmation that the variable was updated.
+
+### 94. Delete Variables (cleanup)
+
+```sh
+tfx varset variable delete --varset-name tfx-test-varset --key TFX_TEST_REGION
+tfx varset variable delete --varset-name tfx-test-varset --key TFX_TEST_ENV
+```
+
+**Expected:** Each deletion confirmed with no errors.
+
+### 95. Delete Variable Set (cleanup)
+
+```sh
+tfx varset delete --name tfx-test-varset
+```
+
+**Expected:** Variable set deleted without error.
+
+---
+
 ## Global Flags
 
 These tests verify cross-cutting behavior available on all commands.
 
-### 84. JSON Output Flag (short form)
+### 96. JSON Output Flag (short form)
 
 ```sh
 tfx workspace list -j
@@ -901,7 +1017,7 @@ tfx workspace list -j
 
 **Expected:** Same JSON output as `--json`.
 
-### 85. Config File Flag
+### 97. Config File Flag
 
 ```sh
 tfx organization list --config-file /path/to/custom/.tfx.hcl
@@ -909,7 +1025,7 @@ tfx organization list --config-file /path/to/custom/.tfx.hcl
 
 **Expected:** Command runs using the specified config file (confirmation message includes the config path).
 
-### 85a. Config File Env Var
+### 97a. Config File Env Var
 
 ```sh
 TFX_CONFIG_FILE=/path/to/custom/.tfx.hcl tfx organization list
@@ -917,7 +1033,7 @@ TFX_CONFIG_FILE=/path/to/custom/.tfx.hcl tfx organization list
 
 **Expected:** Same result as `--config-file` — config loaded from the env-var path.
 
-### 86. Hostname and Token Flags
+### 98. Hostname and Token Flags
 
 ```sh
 tfx organization list \
@@ -928,7 +1044,7 @@ tfx organization list \
 
 **Expected:** Same output as using the config file — confirms inline flags override the config.
 
-### 87. Missing Required Flag Error
+### 99. Missing Required Flag Error
 
 ```sh
 tfx workspace show
@@ -936,7 +1052,7 @@ tfx workspace show
 
 **Expected:** Error message indicating `--name` is required. Exit code is non-zero.
 
-### 88. Invalid Token Error
+### 100. Invalid Token Error
 
 ```sh
 tfx organization list --token invalid-token-value
@@ -952,7 +1068,8 @@ After completing all sections, confirm:
 
 - [ ] All `list` commands return results or a clear empty-state message
 - [ ] All `show` commands display structured detail views
-- [ ] All `create` → `show` → `delete` workflows complete without error
+- [ ] All `create` → `show` → `delete` workflows complete without error (including variable sets)
 - [ ] `--json` flag produces valid JSON on every command tested
 - [ ] Authentication and config errors produce clear, human-readable messages
+- [ ] Failed commands exit with a non-zero status code
 - [ ] No panics or unhandled exceptions were encountered


### PR DESCRIPTION
## Summary

- Add scoped variable set listing (org, project, workspace, all orgs) and name-based show/delete with scope resolution (#219)
- Add project-owned create, workspace assignment, and `tfx varset variable` subcommands (list, create, update, show, delete)
- Add profile-based lifecycle integration test for local TFE (`TFX_INTEGRATION_PROFILE=local`) with optional `TFX_INTEGRATION_NO_CLEANUP` to retain resources for inspection
- Update docs site (`variable_set.md`, test plan), CHANGELOG, DEVELOPMENT.md, and integration README

## Test plan

- [ ] `task go:build` succeeds
- [ ] `go test ./...` passes (unit tests)
- [ ] `export TFX_INTEGRATION_PROFILE=local && task test:integration-cmd -- -run TestVariableSetLocalProfileLifecycle -v`
- [ ] Manual smoke: `tfx varset list`, `tfx varset create --name …`, `tfx varset variable create/list/delete`
- [ ] Verify docs: `task development:serve-docs` → Variable Sets page and test plan section


Made with [Cursor](https://cursor.com)