### PR TITLE
Add profile ssl_skip_verify for self-signed TFE TLS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * `tfx varset variable` subcommands: `list`, `create`, `update`, `show`, `delete` (#219)
 * Profile-based local varset lifecycle integration test (`TestVariableSetLocalProfileLifecycle`; set `TFX_INTEGRATION_PROFILE=local`)
 * `TFX_INTEGRATION_NO_CLEANUP` env var to retain varsets/variables after the lifecycle integration test
+* Profile `ssl_skip_verify` setting for self-signed TFE TLS certificates (also `--ssl-skip-verify` / `TFE_SSL_SKIP_VERIFY`)
 
 **Changed**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,7 @@ The login flow is an **inline** Bubble Tea TUI (no alt-screen) implemented in `t
 | Hostname | `hostname` | `"app.terraform.io"` | — |
 | Organization | `organization` | (commented placeholder) | — |
 | Token | `token` | — | ✓ |
+| Skip TLS verification | `ssl_skip_verify` | `false` | — |
 
 ### HCL Config Format (`pkg/hclconfig/`)
 
@@ -256,7 +257,7 @@ profile "staging" {
 - `hclconfig.DefaultHostname = "app.terraform.io"`
 
 **Key functions:**
-- `Profile` struct: `Name`, `Hostname`, `Organization`, `Token string`
+- `Profile` struct: `Name`, `Hostname`, `Organization`, `Token string`, `SSLSkipVerify bool`
 - `ListProfiles(path string) ([]Profile, error)` — `nil, nil` when file not found or has no profile blocks
 - `WriteProfile(path, name, hostname, organization, token string) error` — name/hostname default to constants when empty
 
@@ -270,8 +271,8 @@ profile "staging" {
 4. If `--profile` not set → look for profile named `"default"`; if not found return nil
 5. Print `Using config file: <path> (profile: <name>)` (suppressed in `--json` mode)
 6. Merge profile values with correct precedence — only set when no higher-priority source exists:
-   - CLI flags (`--hostname`, `--organization`, `--token`) — highest
-   - Environment variables (`TFE_HOSTNAME`, `TFE_ORGANIZATION`, `TFE_TOKEN`)
+   - CLI flags (`--hostname`, `--organization`, `--token`, `--ssl-skip-verify`) — highest
+   - Environment variables (`TFE_HOSTNAME`, `TFE_ORGANIZATION`, `TFE_TOKEN`, `TFE_SSL_SKIP_VERIFY`)
    - Profile values from config file
    - Defaults — lowest
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -11,7 +11,7 @@ New commands and capabilities for users.
 - [ ] `tfx team` command group
 - [ ] Cloud Agents support
 - [ ] Sentinel Publishing support
-- [ ] Self-signed certificate support for TFE instances
+- [x] Self-signed certificate support for TFE instances
 - [ ] Download workspace plan as JSON
 - [ ] Plan export command
 - [ ] Update `tfx organization` and `tfx project show` to include agent pool settings

--- a/client/client.go
+++ b/client/client.go
@@ -31,13 +31,14 @@ func New(hostname, token, organization string) (*TfxClient, error) {
 // HTTP logging is enabled when TFX_LOG or TFX_LOG_PATH is set.
 // To also attach an APIEventBus (TUI inspector), use NewWithContextAndBus.
 func NewWithContext(ctx context.Context, hostname, token, organization string) (*TfxClient, error) {
-	return NewWithContextAndBus(ctx, hostname, token, organization, nil)
+	return NewWithContextAndBus(ctx, hostname, token, organization, nil, false)
 }
 
 // NewWithContextAndBus creates a new TFE client with optional event bus support.
 // When bus is non-nil a LoggingTransport is always installed (regardless of TFX_LOG)
 // so the TUI inspector panel receives every API call.
-func NewWithContextAndBus(ctx context.Context, hostname, token, organization string, bus *APIEventBus) (*TfxClient, error) {
+// When sslSkipVerify is true, TLS certificate verification is disabled.
+func NewWithContextAndBus(ctx context.Context, hostname, token, organization string, bus *APIEventBus, sslSkipVerify bool) (*TfxClient, error) {
 	if hostname == "" {
 		return nil, fmt.Errorf("hostname is required")
 	}
@@ -52,7 +53,7 @@ func NewWithContextAndBus(ctx context.Context, hostname, token, organization str
 	var httpClient *http.Client
 	if IsTFXLogEnabled() || bus != nil {
 		var err error
-		httpClient, _, err = NewHTTPClientWithLogging(bus)
+		httpClient, _, err = NewHTTPClientWithLogging(bus, sslSkipVerify)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create HTTP client with logging: %w", err)
 		}
@@ -61,9 +62,15 @@ func NewWithContextAndBus(ctx context.Context, hostname, token, organization str
 			Token:      token,
 			HTTPClient: httpClient,
 		}
+	} else if sslSkipVerify {
+		httpClient = HTTPClientForTFE(true)
+		config = &tfe.Config{
+			Address:    fmt.Sprintf("https://%s", hostname),
+			Token:      token,
+			HTTPClient: httpClient,
+		}
 	} else {
-		// No logging and no event bus — use a plain HTTP client.
-		httpClient = newHTTPClientNoLogging()
+		httpClient = &http.Client{}
 		config = &tfe.Config{
 			Address: fmt.Sprintf("https://%s", hostname),
 			Token:   token,
@@ -84,10 +91,4 @@ func NewWithContextAndBus(ctx context.Context, hostname, token, organization str
 		EventBus:         bus,
 		HTTPClient:       httpClient,
 	}, nil
-}
-
-// newHTTPClientNoLogging returns a plain http.Client with no transport wrapping.
-// Used when neither logging nor event bus is needed.
-func newHTTPClientNoLogging() *http.Client {
-	return &http.Client{}
 }

--- a/client/config.go
+++ b/client/config.go
@@ -19,8 +19,9 @@ func NewFromViperWithContext(ctx context.Context) (*TfxClient, error) {
 	hostname := viper.GetString("hostname")
 	token := viper.GetString("token")
 	organization := viper.GetString("organization")
+	sslSkipVerify := viper.GetBool("ssl_skip_verify")
 
-	return NewWithContext(ctx, hostname, token, organization)
+	return NewWithContextAndBus(ctx, hostname, token, organization, nil, sslSkipVerify)
 }
 
 // NewFromViperForTUI creates a TfxClient for TUI mode.
@@ -30,6 +31,7 @@ func NewFromViperForTUI(bus *APIEventBus) (*TfxClient, error) {
 	hostname := viper.GetString("hostname")
 	token := viper.GetString("token")
 	organization := viper.GetString("organization")
+	sslSkipVerify := viper.GetBool("ssl_skip_verify")
 
-	return NewWithContextAndBus(context.Background(), hostname, token, organization, bus)
+	return NewWithContextAndBus(context.Background(), hostname, token, organization, bus, sslSkipVerify)
 }

--- a/client/http_logger.go
+++ b/client/http_logger.go
@@ -310,7 +310,7 @@ func IsTFXLogEnabled() bool {
 // NewHTTPClientWithLogging creates an HTTP client that logs all requests and responses to a file
 // if TFX_LOG_PATH is set, and/or to the terminal if TFX_LOG is set.
 // An optional EventBus may be provided to also publish events for the TUI inspector panel.
-func NewHTTPClientWithLogging(bus *APIEventBus) (*http.Client, io.Closer, error) {
+func NewHTTPClientWithLogging(bus *APIEventBus, sslSkipVerify bool) (*http.Client, io.Closer, error) {
 	var logFile *os.File
 	var err error
 
@@ -340,7 +340,7 @@ func NewHTTPClientWithLogging(bus *APIEventBus) (*http.Client, io.Closer, error)
 	}
 
 	transport := &LoggingTransport{
-		Transport: http.DefaultTransport,
+		Transport: baseTransport(sslSkipVerify),
 		LogFile:   logFile,
 		EventBus:  bus,
 	}

--- a/client/http_logger_test.go
+++ b/client/http_logger_test.go
@@ -144,7 +144,7 @@ func TestIsTFXLogEnabled(t *testing.T) {
 
 func TestNewHTTPClientWithLogging(t *testing.T) {
 	t.Run("creates client", func(t *testing.T) {
-		client, closer, err := NewHTTPClientWithLogging(nil)
+		client, closer, err := NewHTTPClientWithLogging(nil, false)
 		if err != nil {
 			t.Fatalf("NewHTTPClientWithLogging() error = %v", err)
 		}

--- a/client/tls.go
+++ b/client/tls.go
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+// Copyright © 2025 Tom Straub <github.com/straubt1>
+
+package client
+
+import (
+	"crypto/tls"
+	"net/http"
+)
+
+func baseTransport(sslSkipVerify bool) *http.Transport {
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	if sslSkipVerify {
+		if tr.TLSClientConfig == nil {
+			tr.TLSClientConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+		}
+		tr.TLSClientConfig.InsecureSkipVerify = true
+	}
+	return tr
+}
+
+// HTTPClientForTFE returns an http.Client configured for TFE API calls.
+func HTTPClientForTFE(sslSkipVerify bool) *http.Client {
+	if !sslSkipVerify {
+		return &http.Client{}
+	}
+	return &http.Client{Transport: baseTransport(true)}
+}

--- a/client/tls_test.go
+++ b/client/tls_test.go
@@ -1,0 +1,51 @@
+// SPDX-License-Identifier: MIT
+// Copyright © 2025 Tom Straub <github.com/straubt1>
+
+package client
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestHTTPClientForTFE_SkipVerify(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		c := HTTPClientForTFE(false)
+		if c.Transport != nil {
+			t.Fatal("expected nil transport when ssl skip verify is disabled")
+		}
+	})
+
+	t.Run("enabled sets InsecureSkipVerify", func(t *testing.T) {
+		c := HTTPClientForTFE(true)
+		tr, ok := c.Transport.(*http.Transport)
+		if !ok {
+			t.Fatalf("expected *http.Transport, got %T", c.Transport)
+		}
+		if tr.TLSClientConfig == nil || !tr.TLSClientConfig.InsecureSkipVerify {
+			t.Fatal("expected InsecureSkipVerify to be true")
+		}
+	})
+}
+
+func TestNewHTTPClientWithLogging_SkipVerify(t *testing.T) {
+	client, closer, err := NewHTTPClientWithLogging(nil, true)
+	if err != nil {
+		t.Fatalf("NewHTTPClientWithLogging() error = %v", err)
+	}
+	if closer != nil {
+		defer func() { _ = closer.Close() }()
+	}
+
+	lt, ok := client.Transport.(*LoggingTransport)
+	if !ok {
+		t.Fatalf("expected *LoggingTransport, got %T", client.Transport)
+	}
+	tr, ok := lt.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport, got %T", lt.Transport)
+	}
+	if tr.TLSClientConfig == nil || !tr.TLSClientConfig.InsecureSkipVerify {
+		t.Fatal("expected InsecureSkipVerify to be true on logging transport")
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -98,6 +98,7 @@ func init() {
 	rootCmd.PersistentFlags().String("organization", "", "The name of the TFx Organization. Can also be set with the environment variable TFE_ORGANIZATION.")
 	rootCmd.PersistentFlags().String("token", "", "The API token used to authenticate to TFx. Can also be set with the environment variable TFE_TOKEN.")
 	rootCmd.PersistentFlags().StringP("profile", "p", "", "Named profile to use from the config file. Defaults to \"default\". Can also be set with the environment variable TFX_PROFILE.")
+	rootCmd.PersistentFlags().Bool("ssl-skip-verify", false, "Skip TLS certificate verification. Can also be set with the environment variable TFE_SSL_SKIP_VERIFY or profile ssl_skip_verify.")
 
 	// Add json output option
 	rootCmd.PersistentFlags().BoolP("json", "j", false, "Will output command results as JSON.")
@@ -107,6 +108,7 @@ func init() {
 	viper.BindEnv("organization", "TFE_ORGANIZATION")
 	viper.BindEnv("token", "TFE_TOKEN")
 	viper.BindEnv("profile", "TFX_PROFILE")
+	viper.BindEnv("ssl_skip_verify", "TFE_SSL_SKIP_VERIFY")
 
 	// Hidden flag for VHS tape recording
 	rootCmd.Flags().String("tape", "", "Record TUI input to a .tape file for VHS (e.g. debug/demo.tape)")
@@ -114,6 +116,8 @@ func init() {
 
 	// Turn off completion option
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
+
+	viper.BindPFlag("ssl_skip_verify", rootCmd.PersistentFlags().Lookup("ssl-skip-verify"))
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -175,6 +179,9 @@ func captureUserFlags() {
 			userChangedFlags[f.Name] = true
 		}
 	})
+	if userChangedFlags["ssl-skip-verify"] {
+		userChangedFlags["ssl_skip_verify"] = true
+	}
 }
 
 // resolveProfile loads profile blocks from the config file and merges the
@@ -253,6 +260,12 @@ func resolveProfile() error {
 		}
 		if m.value != "" {
 			viper.Set(m.viperKey, m.value)
+		}
+	}
+
+	if !userChangedFlags["ssl_skip_verify"] && os.Getenv("TFE_SSL_SKIP_VERIFY") == "" {
+		if active.SSLSkipVerify {
+			viper.Set("ssl_skip_verify", true)
 		}
 	}
 

--- a/cmd/root_config_test.go
+++ b/cmd/root_config_test.go
@@ -58,6 +58,35 @@ profile "default" {
 	if got := viper.GetString("profile"); got != "default" {
 		t.Errorf("expected profile=default, got %q", got)
 	}
+	if viper.GetBool("ssl_skip_verify") {
+		t.Error("expected ssl_skip_verify=false when absent from profile")
+	}
+}
+
+func TestResolveProfile_SSLSkipVerify_FlagOverridesAbsentProfile(t *testing.T) {
+	resetState(t)
+	path := writeConfig(t, `
+profile "local" {
+  hostname     = "local.tfe.rocks"
+  organization = "local-org"
+  token        = "local-tok"
+}
+`)
+	viper.SetConfigFile(path)
+	viper.ReadInConfig()
+	viper.Set("profile", "local")
+	userChangedFlags["ssl-skip-verify"] = true
+	userChangedFlags["ssl_skip_verify"] = true
+	viper.Set("ssl_skip_verify", true)
+
+	err := resolveProfile()
+	if err != nil {
+		t.Fatalf("resolveProfile() error = %v", err)
+	}
+
+	if !viper.GetBool("ssl_skip_verify") {
+		t.Error("expected --ssl-skip-verify flag to set ssl_skip_verify=true")
+	}
 }
 
 func TestResolveProfile_NamedProfile(t *testing.T) {
@@ -274,5 +303,55 @@ profile "default" {
 	// Token from profile (no flag override)
 	if got := viper.GetString("token"); got != "default-tok" {
 		t.Errorf("expected token=default-tok, got %q", got)
+	}
+}
+
+func TestResolveProfile_SSLSkipVerify(t *testing.T) {
+	resetState(t)
+	path := writeConfig(t, `
+profile "local" {
+  hostname        = "local.tfe.rocks"
+  organization    = "local-org"
+  token           = "local-tok"
+  ssl_skip_verify = true
+}
+`)
+	viper.SetConfigFile(path)
+	viper.ReadInConfig()
+	viper.Set("profile", "local")
+
+	err := resolveProfile()
+	if err != nil {
+		t.Fatalf("resolveProfile() error = %v", err)
+	}
+
+	if !viper.GetBool("ssl_skip_verify") {
+		t.Error("expected ssl_skip_verify=true from profile")
+	}
+}
+
+func TestResolveProfile_SSLSkipVerify_EnvOverridesProfile(t *testing.T) {
+	resetState(t)
+	path := writeConfig(t, `
+profile "local" {
+  hostname        = "local.tfe.rocks"
+  organization    = "local-org"
+  token           = "local-tok"
+  ssl_skip_verify = true
+}
+`)
+	viper.SetConfigFile(path)
+	viper.ReadInConfig()
+	viper.Set("profile", "local")
+	viper.BindEnv("ssl_skip_verify", "TFE_SSL_SKIP_VERIFY")
+	t.Setenv("TFE_SSL_SKIP_VERIFY", "false")
+
+	err := resolveProfile()
+	if err != nil {
+		t.Fatalf("resolveProfile() error = %v", err)
+	}
+
+	if viper.GetBool("ssl_skip_verify") {
+		t.Error("expected env TFE_SSL_SKIP_VERIFY=false to override profile")
 	}
 }

--- a/integration/README.md
+++ b/integration/README.md
@@ -71,9 +71,10 @@ For a TFE instance at `local.tfe.rocks`, add a profile to `~/.tfx.hcl`:
 
 ```hcl
 profile "local" {
-  hostname     = "local.tfe.rocks"
-  organization = "your-org"
-  token        = "your-token"
+  hostname        = "local.tfe.rocks"
+  organization    = "your-org"
+  token           = "your-token"
+  ssl_skip_verify = true
 }
 ```
 

--- a/pkg/hclconfig/hclconfig.go
+++ b/pkg/hclconfig/hclconfig.go
@@ -35,15 +35,17 @@ const (
 
 // Profile holds configuration for one TFx profile.
 type Profile struct {
-	Name         string // block label — user-editable alias
-	Hostname     string // hostname value; defaults to DefaultHostname if omitted
-	Organization string // organization value; may be empty
-	Token        string // token value
+	Name          string // block label — user-editable alias
+	Hostname      string // hostname value; defaults to DefaultHostname if omitted
+	Organization  string // organization value; may be empty
+	Token         string // token value
+	SSLSkipVerify bool   // when true, skip TLS certificate verification
 }
 
 var (
 	reProfileStart = regexp.MustCompile(`^profile\s+"([^"]+)"\s*\{`)
 	reKeyValue     = regexp.MustCompile(`^\s+(hostname|organization|token)\s*=\s*"([^"]*)"`)
+	reBoolKeyValue = regexp.MustCompile(`^\s+(ssl_skip_verify)\s*=\s*(true|false)`)
 	reBlockEnd     = regexp.MustCompile(`^\}`)
 )
 
@@ -92,6 +94,12 @@ func ListProfiles(path string) ([]Profile, error) {
 				}
 				continue
 			}
+			if m := reBoolKeyValue.FindStringSubmatch(line); m != nil {
+				if m[1] == "ssl_skip_verify" {
+					current.SSLSkipVerify = m[2] == "true"
+				}
+				continue
+			}
 			if reBlockEnd.MatchString(line) {
 				if current.Hostname == "" {
 					current.Hostname = DefaultHostname
@@ -129,15 +137,29 @@ func WriteProfile(path, name, hostname, organization, token string) error {
 
 	stripped := removeProfileBlock(existing, name)
 
+	sslSkipVerify := false
+	if profiles, err := ListProfiles(path); err == nil {
+		for _, p := range profiles {
+			if p.Name == name {
+				sslSkipVerify = p.SSLSkipVerify
+				break
+			}
+		}
+	}
+
 	var orgLine string
 	if organization != "" {
 		orgLine = fmt.Sprintf("  organization = %q", organization)
 	} else {
 		orgLine = `  # organization = "" # set this to your organization name`
 	}
+	var sslLine string
+	if sslSkipVerify {
+		sslLine = "  ssl_skip_verify  = true\n"
+	}
 	block := fmt.Sprintf(
-		"\nprofile %q {\n  hostname     = %q\n%s\n  token        = %q\n}\n",
-		name, hostname, orgLine, token,
+		"\nprofile %q {\n  hostname     = %q\n%s\n  token        = %q\n%s}\n",
+		name, hostname, orgLine, token, sslLine,
 	)
 
 	content := strings.TrimRight(stripped, "\n\t ")

--- a/pkg/hclconfig/hclconfig_test.go
+++ b/pkg/hclconfig/hclconfig_test.go
@@ -113,6 +113,9 @@ func TestListProfiles_SingleProfile(t *testing.T) {
 	if p.Token != "tok123" {
 		t.Errorf("expected token 'tok123', got %q", p.Token)
 	}
+	if p.SSLSkipVerify {
+		t.Error("expected ssl_skip_verify=false when absent from profile")
+	}
 }
 
 func TestListProfiles_MultipleProfiles(t *testing.T) {
@@ -240,5 +243,72 @@ func TestWriteProfile_UpdatesExistingProfile(t *testing.T) {
 	}
 	if profiles[0].Hostname != "new.host" || profiles[0].Token != "tok2" {
 		t.Errorf("profile not updated: %+v", profiles[0])
+	}
+}
+
+func TestListProfiles_SSLSkipVerify(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".tfx.hcl")
+
+	config := `profile "local" {
+  hostname        = "local.tfe.rocks"
+  organization    = "my-org"
+  token           = "tok123"
+  ssl_skip_verify = true
+}
+profile "cloud" {
+  hostname     = "app.terraform.io"
+  organization = "my-org"
+  token        = "tok456"
+  ssl_skip_verify = false
+}
+`
+	os.WriteFile(path, []byte(config), 0600)
+
+	profiles, err := ListProfiles(path)
+	if err != nil {
+		t.Fatalf("ListProfiles() error = %v", err)
+	}
+	if len(profiles) != 2 {
+		t.Fatalf("expected 2 profiles, got %d", len(profiles))
+	}
+	if !profiles[0].SSLSkipVerify {
+		t.Error("expected local profile ssl_skip_verify=true")
+	}
+	if profiles[1].SSLSkipVerify {
+		t.Error("expected cloud profile ssl_skip_verify=false")
+	}
+}
+
+func TestWriteProfile_PreservesSSLSkipVerify(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, ".tfx.hcl")
+
+	config := `profile "local" {
+  hostname        = "local.tfe.rocks"
+  organization    = "org1"
+  token           = "tok1"
+  ssl_skip_verify = true
+}
+`
+	os.WriteFile(path, []byte(config), 0600)
+
+	err := WriteProfile(path, "local", "local.tfe.rocks", "org2", "tok2")
+	if err != nil {
+		t.Fatalf("WriteProfile() error = %v", err)
+	}
+
+	profiles, err := ListProfiles(path)
+	if err != nil {
+		t.Fatalf("ListProfiles() error = %v", err)
+	}
+	if len(profiles) != 1 {
+		t.Fatalf("expected 1 profile, got %d", len(profiles))
+	}
+	if !profiles[0].SSLSkipVerify {
+		t.Error("expected ssl_skip_verify to be preserved after WriteProfile")
+	}
+	if profiles[0].Organization != "org2" {
+		t.Errorf("expected organization org2, got %q", profiles[0].Organization)
 	}
 }

--- a/site/astro.config.mjs
+++ b/site/astro.config.mjs
@@ -17,6 +17,12 @@ export default defineConfig({
       sidebar: [
         { label: 'Getting Started', slug: 'gettingstarted' },
         {
+          label: 'Configuration',
+          items: [
+            { label: 'Self-Signed TLS', slug: 'configuration/self-signed-tls' },
+          ],
+        },
+        {
           label: 'Interactive TUI',
           items: [
             { label: 'Overview', slug: 'tui/overview' },

--- a/site/src/content/docs/configuration/self-signed-tls.md
+++ b/site/src/content/docs/configuration/self-signed-tls.md
@@ -1,0 +1,88 @@
+---
+title: Self-Signed TLS
+description: Skip TLS verification for local Terraform Enterprise development and testing when certificates are not in your trust store.
+---
+
+Production **Terraform Enterprise** and **HCP Terraform** deployments typically use certificates your system already trusts — no extra configuration is required.
+
+This page is for a narrower case: **local development and testing**, where TFE may run with a self-signed certificate or a private CA that is not installed on your machine (for example a `local.tfe.rocks` dev instance). In that situation, TFx API calls can fail with:
+
+```
+tls: failed to verify certificate: x509: certificate signed by unknown authority
+```
+
+TFx can skip TLS certificate verification in those environments. **This is off by default** — you must opt in explicitly.
+
+:::danger[Security implications]
+When `ssl_skip_verify` is enabled, TFx **does not validate** the server's identity. A network attacker could intercept API traffic, read your token, and impersonate your TFE instance.
+
+**Only use this for local dev or isolated test environments** where you accept that risk. Do not enable it for production or shared staging systems unless you fully understand the exposure.
+
+**Prefer trusting the certificate instead** — add the signing CA or cert to your OS trust store (see [Alternatives](#alternatives) below). That keeps encryption and identity verification intact.
+:::
+
+:::caution[Not the default path]
+Most TFE users never need this setting. If your instance presents a trusted certificate, leave `ssl_skip_verify` unset (or `false`) and skip this page entirely.
+:::
+
+## Profile setting (recommended)
+
+Add `ssl_skip_verify = true` to the profile block in `~/.tfx.hcl`:
+
+```hcl
+profile "local" {
+  hostname        = "local.tfe.rocks"
+  organization    = "org-alpha"
+  token           = "your-token"
+  ssl_skip_verify = true
+}
+```
+
+When the key is **absent**, TFx treats it as `false` and performs normal certificate verification.
+
+Use the profile as usual:
+
+```sh
+tfx varset list --profile local
+tfx --profile local          # TUI
+```
+
+`ssl_skip_verify` is preserved when you re-authenticate with `tfx login` on an existing profile — you do not need to set it again after updating a token.
+
+## One-off CLI flag
+
+For a single command without editing the config file:
+
+```sh
+tfx workspace list --profile local --ssl-skip-verify
+```
+
+## Environment variable
+
+Set `TFE_SSL_SKIP_VERIFY` when you need skip-verify before a profile exists (for example during the first `tfx login` against a self-signed host):
+
+```sh
+export TFE_SSL_SKIP_VERIFY=true
+tfx login local.tfe.rocks
+```
+
+You can combine it with a profile that already has `ssl_skip_verify = true`:
+
+```sh
+TFE_SSL_SKIP_VERIFY=true tfx varset list --profile local
+```
+
+## Configuration precedence
+
+When multiple sources are set, the highest-precedence source wins:
+
+1. **CLI flag** — `--ssl-skip-verify`
+2. **Environment variable** — `TFE_SSL_SKIP_VERIFY`
+3. **Profile value** — `ssl_skip_verify` in `.tfx.hcl`
+4. **Default** — `false`
+
+## Alternatives (recommended)
+
+Before enabling `ssl_skip_verify`, consider installing the certificate in your system trust store. TFx uses the same trust store as other HTTPS clients — once the CA or cert is trusted, no skip-verify setting is needed.
+
+For local development, tools like [mkcert](https://github.com/FiloSottile/mkcert) can issue certificates your machine trusts by default. That is the safer long-term approach for repeated dev work against a local TFE instance.

--- a/site/src/content/docs/gettingstarted.mdx
+++ b/site/src/content/docs/gettingstarted.mdx
@@ -109,6 +109,8 @@ profile "production" {
 | Organization | `organization` | _(none)_ | No |
 | Token | `token` | _(none)_ | Yes |
 
+For self-signed or private-CA Terraform Enterprise instances, see [Self-Signed TLS](/configuration/self-signed-tls/) — most users can skip this page.
+
 ### Selecting a profile
 
 By default, TFx uses the profile named `default`. To use a different profile:
@@ -144,9 +146,9 @@ The flag takes precedence over the env var; both override auto-discovery.
 
 When the same setting is specified in multiple places, the highest-precedence source wins:
 
-1. **CLI flags** (`--hostname`, `--organization`, `--token`) — highest
-2. **Environment variables** (`TFE_HOSTNAME`, `TFE_ORGANIZATION`, `TFE_TOKEN`)
+1. **CLI flags** (`--hostname`, `--organization`, `--token`, `--ssl-skip-verify`) — highest
+2. **Environment variables** (`TFE_HOSTNAME`, `TFE_ORGANIZATION`, `TFE_TOKEN`, `TFE_SSL_SKIP_VERIFY`)
 3. **Profile values** from `.tfx.hcl`
-4. **Defaults** (`hostname` defaults to `app.terraform.io`)
+4. **Defaults** (`hostname` defaults to `app.terraform.io`; TLS verification is enabled)
 
 

--- a/tui/login.go
+++ b/tui/login.go
@@ -6,6 +6,8 @@ package tui
 import (
 	"context"
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 	"time"
 
@@ -13,6 +15,7 @@ import (
 	"charm.land/lipgloss/v2"
 	tfe "github.com/hashicorp/go-tfe"
 
+	"github.com/straubt1/tfx/client"
 	"github.com/straubt1/tfx/pkg/browser"
 	"github.com/straubt1/tfx/pkg/hclconfig"
 )
@@ -50,11 +53,12 @@ func loginTickSpinner() tea.Cmd {
 	}
 }
 
-func loginFetchOrgs(hostname, token string) tea.Cmd {
+func loginFetchOrgs(hostname, token string, sslSkipVerify bool) tea.Cmd {
 	return func() tea.Msg {
 		tfeClient, err := tfe.NewClient(&tfe.Config{
-			Address: "https://" + hostname,
-			Token:   token,
+			Address:    "https://" + hostname,
+			Token:      token,
+			HTTPClient: client.HTTPClientForTFE(sslSkipVerify),
 		})
 		if err != nil {
 			return loginErrMsg{err}
@@ -103,6 +107,7 @@ type LoginModel struct {
 	orgCursor           int
 	selectedOrg         string
 	resolvedToken       string
+	sslSkipVerify       bool
 	spinnerIdx          int
 	err                 error               // fatal write/config error
 	width               int
@@ -195,6 +200,7 @@ func (m LoginModel) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 				p := m.profiles[m.profileCursor-1]
 				m.hostname = p.Hostname
 				m.selectedProfileName = p.Name
+				m.sslSkipVerify = p.SSLSkipVerify
 				m.isUpdate = true
 				m.step = stepMenu
 			}
@@ -264,7 +270,7 @@ func (m LoginModel) handleKey(msg tea.KeyPressMsg) (tea.Model, tea.Cmd) {
 			}
 			m.resolvedToken = token
 			m.step = stepValidating
-			return m, tea.Batch(loginFetchOrgs(m.hostname, token), loginTickSpinner())
+			return m, tea.Batch(loginFetchOrgs(m.hostname, token, m.sslSkipVerify), loginTickSpinner())
 		case "backspace":
 			if len(m.tokenRunes) > 0 {
 				m.tokenRunes = m.tokenRunes[:len(m.tokenRunes)-1]
@@ -526,8 +532,6 @@ func (m LoginModel) render() string {
 	return b.String()
 }
 
-// ── Entry point ───────────────────────────────────────────────────────────────
-
 // RunLogin launches the inline login wizard for the given hostname.
 func RunLogin(hostname string) error {
 	configPath, err := hclconfig.DefaultConfigPath()
@@ -543,10 +547,11 @@ func RunLogin(hostname string) error {
 	}
 
 	m := LoginModel{
-		step:       initialStep,
-		hostname:   hostname,
-		configPath: configPath,
-		profiles:   profiles,
+		step:          initialStep,
+		hostname:      hostname,
+		configPath:    configPath,
+		profiles:      profiles,
+		sslSkipVerify: sslSkipVerifyFromEnv(),
 		// Pre-fill profile name with "default" when starting at the name entry step.
 		nameRunes: []rune(hclconfig.DefaultProfileName),
 	}
@@ -560,4 +565,16 @@ func RunLogin(hostname string) error {
 		return nil
 	}
 	return lm.err
+}
+
+func sslSkipVerifyFromEnv() bool {
+	v := os.Getenv("TFE_SSL_SKIP_VERIFY")
+	if v == "" {
+		return false
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return false
+	}
+	return b
 }


### PR DESCRIPTION
Closes #119

## Summary

- Add optional `ssl_skip_verify = true` profile setting for local dev and testing against TFE instances with untrusted certificates (defaults to `false` when absent)
- Support `--ssl-skip-verify` CLI flag and `TFE_SSL_SKIP_VERIFY` env var, with correct viper binding for the hyphenated flag name
- Wire TLS skip-verify through the API client, login token validation, and HTTP logging transport; preserve the setting on `tfx login` profile rewrites
- Add dedicated docs page at `/configuration/self-signed-tls/` with security guidance; link from Getting Started without cluttering the main profile table

## Test plan

- [x] `go test ./pkg/hclconfig/... ./client/... ./cmd/...`
- [x] Verified `./tfx varset list -p local --ssl-skip-verify` against `local.tfe.rocks`
- [x] Docs site builds (`npm run build` in `site/`)
- [x] Add `ssl_skip_verify = true` to local profile and confirm commands work without the flag