### PR TITLE
Add bulk filter flags for terraform-version enable/disable all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Profile-based local varset lifecycle integration test (`TestVariableSetLocalProfileLifecycle`; set `TFX_INTEGRATION_PROFILE=local`)
 * `TFX_INTEGRATION_NO_CLEANUP` env var to retain varsets/variables after the lifecycle integration test
 * Profile `ssl_skip_verify` setting for self-signed TFE TLS certificates (also `--ssl-skip-verify` / `TFE_SSL_SKIP_VERIFY`)
+* `tfx admin terraform-version disable all` filter flags: `--except`, `--before`, `--not-in-use`, `--beta`, `--deprecated`, `--official`, `--unofficial`
+* `tfx admin terraform-version enable all` filter flags: `--include`, `--except`, `--beta`, `--official`, `--unofficial`
 
 **Changed**
+
+* Bulk terraform-version enable/disable results now report `Enabled` / `Disabled` instead of raw boolean values
 
 * Health check now uses `/api/v1/health/readiness` endpoint (TFE), falling back to `/_health_check` for HCP Terraform and older TFE (#244)
 * Updated task names in docs to match current Taskfile (`go-build` → `go:build`, etc.)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Check out our docs site [tfx.rocks](https://tfx.rocks)
 | `tfx release tfe` | `list`, `show` |
 | `tfx admin gpg` | `list`, `show`, `create`, `delete` |
 | `tfx admin metrics` | `workspace` |
-| `tfx admin terraformversion` | `list`, `show`, `create`, `update`, `delete` |
+| `tfx admin terraform-version` | `list`, `show`, `create`, `create official`, `delete`, `enable`, `enable all`, `disable`, `disable all` |
 
 ## Roadmap
 

--- a/cmd/admin_terraformversion.go
+++ b/cmd/admin_terraformversion.go
@@ -4,8 +4,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/straubt1/tfx/client"
@@ -424,7 +422,24 @@ func tfvDisableAll(cmdConfig *flags.AdminTerraformVersionDisableAllFlags) error 
 		return v.RenderError(err)
 	}
 
-	v.PrintCommandHeader(disableAllHeader(cmdConfig))
+	switch {
+	case len(cmdConfig.Except) > 0:
+		v.PrintCommandHeader("Disabling all Terraform versions except: %v", cmdConfig.Except)
+	case cmdConfig.Before != "":
+		v.PrintCommandHeader("Disabling all Terraform versions before %s", cmdConfig.Before)
+	case cmdConfig.NotInUse:
+		v.PrintCommandHeader("Disabling unused Terraform versions")
+	case cmdConfig.Beta:
+		v.PrintCommandHeader("Disabling beta Terraform versions")
+	case cmdConfig.Deprecated:
+		v.PrintCommandHeader("Disabling deprecated Terraform versions")
+	case cmdConfig.Unofficial:
+		v.PrintCommandHeader("Disabling unofficial Terraform versions")
+	case cmdConfig.Official:
+		v.PrintCommandHeader("Disabling official Terraform versions")
+	default:
+		v.PrintCommandHeader("Disabling all Terraform versions")
+	}
 
 	// Fetch all versions
 	items, err := data.FetchTerraformVersions(c, "", "")
@@ -453,27 +468,6 @@ func tfvDisableAll(cmdConfig *flags.AdminTerraformVersionDisableAllFlags) error 
 	}
 
 	return v.Render(results)
-}
-
-func disableAllHeader(cmdConfig *flags.AdminTerraformVersionDisableAllFlags) string {
-	switch {
-	case len(cmdConfig.Except) > 0:
-		return fmt.Sprintf("Disabling all Terraform versions except: %v", cmdConfig.Except)
-	case cmdConfig.Before != "":
-		return fmt.Sprintf("Disabling all Terraform versions before %s", cmdConfig.Before)
-	case cmdConfig.NotInUse:
-		return "Disabling unused Terraform versions"
-	case cmdConfig.Beta:
-		return "Disabling beta Terraform versions"
-	case cmdConfig.Deprecated:
-		return "Disabling deprecated Terraform versions"
-	case cmdConfig.Unofficial:
-		return "Disabling unofficial Terraform versions"
-	case cmdConfig.Official:
-		return "Disabling official Terraform versions"
-	default:
-		return "Disabling all Terraform versions"
-	}
 }
 
 func tfvEnable(cmdConfig *flags.AdminTerraformVersionEnableDisableFlags) error {
@@ -506,7 +500,20 @@ func tfvEnableAll(cmdConfig *flags.AdminTerraformVersionEnableAllFlags) error {
 		return v.RenderError(err)
 	}
 
-	v.PrintCommandHeader(enableAllHeader(cmdConfig))
+	switch {
+	case len(cmdConfig.Include) > 0:
+		v.PrintCommandHeader("Enabling Terraform versions: %v", cmdConfig.Include)
+	case len(cmdConfig.Except) > 0:
+		v.PrintCommandHeader("Enabling all Terraform versions except: %v", cmdConfig.Except)
+	case cmdConfig.Beta:
+		v.PrintCommandHeader("Enabling beta Terraform versions")
+	case cmdConfig.Unofficial:
+		v.PrintCommandHeader("Enabling unofficial Terraform versions")
+	case cmdConfig.Official:
+		v.PrintCommandHeader("Enabling official Terraform versions")
+	default:
+		v.PrintCommandHeader("Enabling all Terraform versions")
+	}
 
 	// Fetch all versions
 	items, err := data.FetchTerraformVersions(c, "", "")
@@ -533,21 +540,4 @@ func tfvEnableAll(cmdConfig *flags.AdminTerraformVersionEnableAllFlags) error {
 	}
 
 	return v.Render(results)
-}
-
-func enableAllHeader(cmdConfig *flags.AdminTerraformVersionEnableAllFlags) string {
-	switch {
-	case len(cmdConfig.Include) > 0:
-		return fmt.Sprintf("Enabling Terraform versions: %v", cmdConfig.Include)
-	case len(cmdConfig.Except) > 0:
-		return fmt.Sprintf("Enabling all Terraform versions except: %v", cmdConfig.Except)
-	case cmdConfig.Beta:
-		return "Enabling beta Terraform versions"
-	case cmdConfig.Unofficial:
-		return "Enabling unofficial Terraform versions"
-	case cmdConfig.Official:
-		return "Enabling official Terraform versions"
-	default:
-		return "Enabling all Terraform versions"
-	}
 }

--- a/cmd/admin_terraformversion.go
+++ b/cmd/admin_terraformversion.go
@@ -4,6 +4,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/straubt1/tfx/client"
@@ -42,7 +44,16 @@ Enable specific versions:
 tfx admin terraform-version enable --versions 1.5.0,1.5.1
 
 Disable specific versions:
-tfx admin terraform-version disable --versions 1.4.0,1.4.1`,
+tfx admin terraform-version disable --versions 1.4.0,1.4.1
+
+Disable all versions except a keep-list:
+tfx admin terraform-version disable all --except 1.12.0,1.13.0
+
+Disable all unused versions:
+tfx admin terraform-version disable all --not-in-use
+
+Disable all versions before 1.12.0:
+tfx admin terraform-version disable all --before 1.12.0`,
 	}
 
 	// `tfx admin terraform-version list` command
@@ -149,11 +160,19 @@ tfx admin terraform-version disable --versions 1.4.0,1.4.1`,
 	tfvDisableAllCmd = &cobra.Command{
 		Use:   "all",
 		Short: "Disable All Terraform Versions",
-		Long:  "Disable All Terraform Versions in a TFE Installation.",
+		Long:  "Disable All Terraform Versions in a TFE Installation. Optional filter flags select a subset.",
 		Example: `
-tfx admin terraform-version disable all`,
+tfx admin terraform-version disable all
+
+tfx admin terraform-version disable all --except 1.12.0,1.13.0
+
+tfx admin terraform-version disable all --not-in-use
+
+tfx admin terraform-version disable all --beta
+
+tfx admin terraform-version disable all --before 1.12.0`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmdConfig, err := flags.ParseAdminTerraformVersionEnableDisableFlags(cmd)
+			cmdConfig, err := flags.ParseAdminTerraformVersionDisableAllFlags(cmd)
 			if err != nil {
 				return err
 			}
@@ -181,11 +200,17 @@ tfx admin terraform-version enable --versions 1.5.0,1.5.1`,
 	tfvEnableAllCmd = &cobra.Command{
 		Use:   "all",
 		Short: "Enable All Terraform Versions",
-		Long:  "Enable All Terraform Versions in a TFE Installation.",
+		Long:  "Enable All Terraform Versions in a TFE Installation. Optional filter flags select a subset.",
 		Example: `
-tfx admin terraform-version enable all`,
+tfx admin terraform-version enable all
+
+tfx admin terraform-version enable all --include 1.12.0,1.13.0
+
+tfx admin terraform-version enable all --except 1.12.0,1.13.0
+
+tfx admin terraform-version enable all --beta`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			cmdConfig, err := flags.ParseAdminTerraformVersionEnableDisableFlags(cmd)
+			cmdConfig, err := flags.ParseAdminTerraformVersionEnableAllFlags(cmd)
 			if err != nil {
 				return err
 			}
@@ -227,9 +252,25 @@ func init() {
 	tfvDisableCmd.Flags().StringSliceP("versions", "v", []string{}, "Versions to disable, can be comma separated (e.g., 1.4.0,1.4.1)")
 	tfvDisableCmd.MarkFlagRequired("versions")
 
+	// `tfx admin terraform-version disable all` flags
+	tfvDisableAllCmd.Flags().StringSlice("except", []string{}, "Versions to keep enabled; disable all others (comma separated)")
+	tfvDisableAllCmd.Flags().String("before", "", "Disable all versions strictly before this semver (e.g., 1.12.0)")
+	tfvDisableAllCmd.Flags().Bool("not-in-use", false, "Disable only versions with no workspace usage")
+	tfvDisableAllCmd.Flags().Bool("beta", false, "Disable only beta versions")
+	tfvDisableAllCmd.Flags().Bool("deprecated", false, "Disable only deprecated versions")
+	tfvDisableAllCmd.Flags().Bool("unofficial", false, "Disable only unofficial versions")
+	tfvDisableAllCmd.Flags().Bool("official", false, "Disable only official versions")
+
 	// `tfx admin terraform-version enable` flags
 	tfvEnableCmd.Flags().StringSliceP("versions", "v", []string{}, "Versions to enable, can be comma separated (e.g., 1.5.0,1.5.1)")
 	tfvEnableCmd.MarkFlagRequired("versions")
+
+	// `tfx admin terraform-version enable all` flags
+	tfvEnableAllCmd.Flags().StringSlice("include", []string{}, "Enable only these versions (comma separated)")
+	tfvEnableAllCmd.Flags().StringSlice("except", []string{}, "Enable all versions except these (comma separated)")
+	tfvEnableAllCmd.Flags().Bool("beta", false, "Enable only beta versions")
+	tfvEnableAllCmd.Flags().Bool("unofficial", false, "Enable only unofficial versions")
+	tfvEnableAllCmd.Flags().Bool("official", false, "Enable only official versions")
 
 	adminCmd.AddCommand(tfvCmd)
 	tfvCmd.AddCommand(tfvListCmd)
@@ -374,7 +415,7 @@ func tfvDisable(cmdConfig *flags.AdminTerraformVersionEnableDisableFlags) error 
 	return v.Render(results)
 }
 
-func tfvDisableAll(cmdConfig *flags.AdminTerraformVersionEnableDisableFlags) error {
+func tfvDisableAll(cmdConfig *flags.AdminTerraformVersionDisableAllFlags) error {
 	// Create view for rendering
 	v := view.NewAdminTerraformVersionUpdateView()
 
@@ -383,8 +424,7 @@ func tfvDisableAll(cmdConfig *flags.AdminTerraformVersionEnableDisableFlags) err
 		return v.RenderError(err)
 	}
 
-	// Print command header
-	v.PrintCommandHeader("Disabling all Terraform versions")
+	v.PrintCommandHeader(disableAllHeader(cmdConfig))
 
 	// Fetch all versions
 	items, err := data.FetchTerraformVersions(c, "", "")
@@ -392,19 +432,48 @@ func tfvDisableAll(cmdConfig *flags.AdminTerraformVersionEnableDisableFlags) err
 		return v.RenderError(errors.Wrap(err, "failed to list terraform versions"))
 	}
 
-	// Extract version strings
-	versions := make([]string, len(items))
-	for i, v := range items {
-		versions[i] = v.Version
+	filter := data.TerraformVersionDisableFilter{
+		Except:     cmdConfig.Except,
+		Before:     cmdConfig.Before,
+		NotInUse:   cmdConfig.NotInUse,
+		Deprecated: cmdConfig.Deprecated,
+		Unofficial: cmdConfig.Unofficial,
+		Official:   cmdConfig.Official,
+		Beta:       cmdConfig.Beta,
+	}
+	versions := data.FilterVersionsForDisable(items, filter)
+	if len(versions) == 0 {
+		return v.RenderError(errors.New("no terraform versions matched filter"))
 	}
 
-	// Disable all versions
+	// Disable selected versions
 	results, err := data.UpdateTerraformVersions(c, versions, false)
 	if err != nil {
 		return v.RenderError(err)
 	}
 
 	return v.Render(results)
+}
+
+func disableAllHeader(cmdConfig *flags.AdminTerraformVersionDisableAllFlags) string {
+	switch {
+	case len(cmdConfig.Except) > 0:
+		return fmt.Sprintf("Disabling all Terraform versions except: %v", cmdConfig.Except)
+	case cmdConfig.Before != "":
+		return fmt.Sprintf("Disabling all Terraform versions before %s", cmdConfig.Before)
+	case cmdConfig.NotInUse:
+		return "Disabling unused Terraform versions"
+	case cmdConfig.Beta:
+		return "Disabling beta Terraform versions"
+	case cmdConfig.Deprecated:
+		return "Disabling deprecated Terraform versions"
+	case cmdConfig.Unofficial:
+		return "Disabling unofficial Terraform versions"
+	case cmdConfig.Official:
+		return "Disabling official Terraform versions"
+	default:
+		return "Disabling all Terraform versions"
+	}
 }
 
 func tfvEnable(cmdConfig *flags.AdminTerraformVersionEnableDisableFlags) error {
@@ -428,7 +497,7 @@ func tfvEnable(cmdConfig *flags.AdminTerraformVersionEnableDisableFlags) error {
 	return v.Render(results)
 }
 
-func tfvEnableAll(cmdConfig *flags.AdminTerraformVersionEnableDisableFlags) error {
+func tfvEnableAll(cmdConfig *flags.AdminTerraformVersionEnableAllFlags) error {
 	// Create view for rendering
 	v := view.NewAdminTerraformVersionUpdateView()
 
@@ -437,8 +506,7 @@ func tfvEnableAll(cmdConfig *flags.AdminTerraformVersionEnableDisableFlags) erro
 		return v.RenderError(err)
 	}
 
-	// Print command header
-	v.PrintCommandHeader("Enabling all Terraform versions")
+	v.PrintCommandHeader(enableAllHeader(cmdConfig))
 
 	// Fetch all versions
 	items, err := data.FetchTerraformVersions(c, "", "")
@@ -446,17 +514,40 @@ func tfvEnableAll(cmdConfig *flags.AdminTerraformVersionEnableDisableFlags) erro
 		return v.RenderError(errors.Wrap(err, "failed to list terraform versions"))
 	}
 
-	// Extract version strings
-	versions := make([]string, len(items))
-	for i, v := range items {
-		versions[i] = v.Version
+	filter := data.TerraformVersionEnableFilter{
+		Include:    cmdConfig.Include,
+		Except:     cmdConfig.Except,
+		Unofficial: cmdConfig.Unofficial,
+		Official:   cmdConfig.Official,
+		Beta:       cmdConfig.Beta,
+	}
+	versions := data.FilterVersionsForEnable(items, filter)
+	if len(versions) == 0 {
+		return v.RenderError(errors.New("no terraform versions matched filter"))
 	}
 
-	// Enable all versions
+	// Enable selected versions
 	results, err := data.UpdateTerraformVersions(c, versions, true)
 	if err != nil {
 		return v.RenderError(err)
 	}
 
 	return v.Render(results)
+}
+
+func enableAllHeader(cmdConfig *flags.AdminTerraformVersionEnableAllFlags) string {
+	switch {
+	case len(cmdConfig.Include) > 0:
+		return fmt.Sprintf("Enabling Terraform versions: %v", cmdConfig.Include)
+	case len(cmdConfig.Except) > 0:
+		return fmt.Sprintf("Enabling all Terraform versions except: %v", cmdConfig.Except)
+	case cmdConfig.Beta:
+		return "Enabling beta Terraform versions"
+	case cmdConfig.Unofficial:
+		return "Enabling unofficial Terraform versions"
+	case cmdConfig.Official:
+		return "Enabling official Terraform versions"
+	default:
+		return "Enabling all Terraform versions"
+	}
 }

--- a/cmd/flags/admin_terraformversion.go
+++ b/cmd/flags/admin_terraformversion.go
@@ -50,6 +50,26 @@ type AdminTerraformVersionEnableDisableFlags struct {
 	All      bool
 }
 
+// AdminTerraformVersionDisableAllFlags holds all flags for the admin terraform-version disable all command
+type AdminTerraformVersionDisableAllFlags struct {
+	Except     []string
+	Before     string
+	NotInUse   bool
+	Deprecated bool
+	Unofficial bool
+	Official   bool
+	Beta       bool
+}
+
+// AdminTerraformVersionEnableAllFlags holds all flags for the admin terraform-version enable all command
+type AdminTerraformVersionEnableAllFlags struct {
+	Include    []string
+	Except     []string
+	Unofficial bool
+	Official   bool
+	Beta       bool
+}
+
 // ParseAdminTerraformVersionListFlags creates AdminTerraformVersionListFlags from the current command context
 func ParseAdminTerraformVersionListFlags(cmd *cobra.Command) (*AdminTerraformVersionListFlags, error) {
 	return &AdminTerraformVersionListFlags{
@@ -121,6 +141,118 @@ func ParseAdminTerraformVersionEnableDisableFlags(cmd *cobra.Command) (*AdminTer
 	return &AdminTerraformVersionEnableDisableFlags{
 		Versions: versions,
 		All:      all,
+	}, nil
+}
+
+// ParseAdminTerraformVersionDisableAllFlags creates AdminTerraformVersionDisableAllFlags from the current command context
+func ParseAdminTerraformVersionDisableAllFlags(cmd *cobra.Command) (*AdminTerraformVersionDisableAllFlags, error) {
+	except := viper.GetStringSlice("except")
+	before := viper.GetString("before")
+	notInUse := viper.GetBool("not-in-use")
+	deprecated := viper.GetBool("deprecated")
+	unofficial := viper.GetBool("unofficial")
+	official := viper.GetBool("official")
+	beta := viper.GetBool("beta")
+
+	filterCount := 0
+	if len(except) > 0 {
+		filterCount++
+	}
+	if before != "" {
+		filterCount++
+	}
+	if notInUse {
+		filterCount++
+	}
+	if deprecated {
+		filterCount++
+	}
+	if unofficial {
+		filterCount++
+	}
+	if official {
+		filterCount++
+	}
+	if beta {
+		filterCount++
+	}
+
+	if filterCount > 1 {
+		return nil, errors.New("only one filter flag may be set: --except, --before, --not-in-use, --beta, --deprecated, --official, or --unofficial")
+	}
+
+	if len(except) > 0 {
+		for _, v := range except {
+			if err := validateSemanticVersion(v); err != nil {
+				return nil, errors.Wrapf(err, "invalid version in --except: %s", v)
+			}
+		}
+	}
+
+	if before != "" {
+		if err := validateSemanticVersion(before); err != nil {
+			return nil, errors.Wrapf(err, "invalid version in --before: %s", before)
+		}
+	}
+
+	return &AdminTerraformVersionDisableAllFlags{
+		Except:     except,
+		Before:     before,
+		NotInUse:   notInUse,
+		Deprecated: deprecated,
+		Unofficial: unofficial,
+		Official:   official,
+		Beta:       beta,
+	}, nil
+}
+
+// ParseAdminTerraformVersionEnableAllFlags creates AdminTerraformVersionEnableAllFlags from the current command context
+func ParseAdminTerraformVersionEnableAllFlags(cmd *cobra.Command) (*AdminTerraformVersionEnableAllFlags, error) {
+	include := viper.GetStringSlice("include")
+	except := viper.GetStringSlice("except")
+	unofficial := viper.GetBool("unofficial")
+	official := viper.GetBool("official")
+	beta := viper.GetBool("beta")
+
+	filterCount := 0
+	if len(include) > 0 {
+		filterCount++
+	}
+	if len(except) > 0 {
+		filterCount++
+	}
+	if unofficial {
+		filterCount++
+	}
+	if official {
+		filterCount++
+	}
+	if beta {
+		filterCount++
+	}
+
+	if filterCount > 1 {
+		return nil, errors.New("only one filter flag may be set: --include, --except, --beta, --official, or --unofficial")
+	}
+
+	for _, v := range include {
+		if err := validateSemanticVersion(v); err != nil {
+			return nil, errors.Wrapf(err, "invalid version in --include: %s", v)
+		}
+	}
+
+	for _, v := range except {
+		if err := validateSemanticVersion(v); err != nil {
+			return nil, errors.Wrapf(err, "invalid version in --except: %s", v)
+		}
+	}
+
+	return &AdminTerraformVersionEnableAllFlags{
+		Include:    include,
+		Except:     except,
+		Unofficial: unofficial,
+		Official:   official,
+		Beta:       beta,
 	}, nil
 }
 

--- a/data/admin_terraformversion.go
+++ b/data/admin_terraformversion.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/coreos/go-semver/semver"
 	tfe "github.com/hashicorp/go-tfe"
 	"github.com/pkg/errors"
 	"github.com/straubt1/tfx/client"
@@ -182,6 +183,184 @@ func DeleteTerraformVersion(c *client.TfxClient, version string) error {
 	return nil
 }
 
+// TerraformVersionDisableFilter selects which versions to disable in a bulk disable operation.
+type TerraformVersionDisableFilter struct {
+	Except     []string
+	Before     string
+	NotInUse   bool
+	Deprecated bool
+	Unofficial bool
+	Official   bool
+	Beta       bool
+}
+
+// FilterVersionsForDisable returns version strings from items matching the given filter.
+func FilterVersionsForDisable(items []*tfe.AdminTerraformVersion, f TerraformVersionDisableFilter) []string {
+	if len(f.Except) > 0 {
+		keep := make(map[string]struct{}, len(f.Except))
+		for _, v := range f.Except {
+			keep[v] = struct{}{}
+		}
+		var versions []string
+		for _, item := range items {
+			if _, ok := keep[item.Version]; !ok {
+				versions = append(versions, item.Version)
+			}
+		}
+		return versions
+	}
+
+	if f.Before != "" {
+		cutoff, err := semver.NewVersion(f.Before)
+		if err != nil {
+			return nil
+		}
+		var versions []string
+		for _, item := range items {
+			v, err := semver.NewVersion(item.Version)
+			if err != nil {
+				continue
+			}
+			if v.LessThan(*cutoff) {
+				versions = append(versions, item.Version)
+			}
+		}
+		return versions
+	}
+
+	if f.NotInUse {
+		var versions []string
+		for _, item := range items {
+			if item.Usage == 0 {
+				versions = append(versions, item.Version)
+			}
+		}
+		return versions
+	}
+
+	if f.Deprecated {
+		var versions []string
+		for _, item := range items {
+			if item.Deprecated {
+				versions = append(versions, item.Version)
+			}
+		}
+		return versions
+	}
+
+	if f.Unofficial {
+		var versions []string
+		for _, item := range items {
+			if !item.Official {
+				versions = append(versions, item.Version)
+			}
+		}
+		return versions
+	}
+
+	if f.Official {
+		var versions []string
+		for _, item := range items {
+			if item.Official {
+				versions = append(versions, item.Version)
+			}
+		}
+		return versions
+	}
+
+	if f.Beta {
+		var versions []string
+		for _, item := range items {
+			if item.Beta {
+				versions = append(versions, item.Version)
+			}
+		}
+		return versions
+	}
+
+	versions := make([]string, len(items))
+	for i, item := range items {
+		versions[i] = item.Version
+	}
+	return versions
+}
+
+// TerraformVersionEnableFilter selects which versions to enable in a bulk enable operation.
+type TerraformVersionEnableFilter struct {
+	Include    []string
+	Except     []string
+	Unofficial bool
+	Official   bool
+	Beta       bool
+}
+
+// FilterVersionsForEnable returns version strings from items matching the given filter.
+func FilterVersionsForEnable(items []*tfe.AdminTerraformVersion, f TerraformVersionEnableFilter) []string {
+	if len(f.Include) > 0 {
+		allow := make(map[string]struct{}, len(f.Include))
+		for _, v := range f.Include {
+			allow[v] = struct{}{}
+		}
+		var versions []string
+		for _, item := range items {
+			if _, ok := allow[item.Version]; ok {
+				versions = append(versions, item.Version)
+			}
+		}
+		return versions
+	}
+
+	if len(f.Except) > 0 {
+		skip := make(map[string]struct{}, len(f.Except))
+		for _, v := range f.Except {
+			skip[v] = struct{}{}
+		}
+		var versions []string
+		for _, item := range items {
+			if _, ok := skip[item.Version]; !ok {
+				versions = append(versions, item.Version)
+			}
+		}
+		return versions
+	}
+
+	if f.Unofficial {
+		var versions []string
+		for _, item := range items {
+			if !item.Official {
+				versions = append(versions, item.Version)
+			}
+		}
+		return versions
+	}
+
+	if f.Official {
+		var versions []string
+		for _, item := range items {
+			if item.Official {
+				versions = append(versions, item.Version)
+			}
+		}
+		return versions
+	}
+
+	if f.Beta {
+		var versions []string
+		for _, item := range items {
+			if item.Beta {
+				versions = append(versions, item.Version)
+			}
+		}
+		return versions
+	}
+
+	versions := make([]string, len(items))
+	for i, item := range items {
+		versions[i] = item.Version
+	}
+	return versions
+}
+
 // UpdateTerraformVersions enables or disables multiple Terraform versions
 func UpdateTerraformVersions(c *client.TfxClient, versions []string, enabled bool) (map[string]string, error) {
 	output.Get().Logger().Debug("Updating Terraform versions", "count", len(versions), "enabled", enabled)
@@ -215,7 +394,11 @@ func UpdateTerraformVersions(c *client.TfxClient, versions []string, enabled boo
 			return results, errors.Wrap(err, "failed to update terraform version")
 		}
 
-		results[v] = fmt.Sprintf("%t", tfv.Enabled)
+		if enabled {
+			results[v] = "Enabled"
+		} else {
+			results[v] = "Disabled"
+		}
 	}
 
 	output.Get().Logger().Debug("Terraform versions updated successfully", "results", len(results))

--- a/site/src/content/docs/commands/admin_terraformversion.md
+++ b/site/src/content/docs/commands/admin_terraformversion.md
@@ -12,6 +12,22 @@ These commands will only work with Terraform Enterprise
 All commands below can be used with a `tfv` alias.
 :::
 
+## Command overview
+
+| Subcommand | Description |
+|---|---|
+| `list` | List all Terraform versions (`--search` for substring filter) |
+| `show` | Show details for one version |
+| `create` | Create a custom version from URL and SHA |
+| `create official` | Create a version from HashiCorp releases |
+| `delete` | Delete a version |
+| `disable` | Disable specific versions (`--versions`) |
+| `disable all` | Bulk disable; optional filter flags select a subset |
+| `enable` | Enable specific versions (`--versions`) |
+| `enable all` | Bulk enable; optional filter flags select a subset |
+
+Bulk `disable all` and `enable all` accept at most one filter flag per invocation. See the sections below for flag details and examples.
+
 ## `tfx admin terraform-version list`
 
 List all Terraform Versions for a Terraform Enterprise install.
@@ -159,7 +175,9 @@ Beta:    false
 ## `tfx admin terraform-version disable`
 
 Disable a Terraform Version(s), accepts comma separated list.
-This command will attempt to enable all given versions even if there are failures.
+This command will attempt to disable all given versions even if there are failures.
+
+Successful disables report `Disabled` in the result output.
 
 **Basic Example**
 
@@ -167,9 +185,9 @@ This command will attempt to enable all given versions even if there are failure
 $ tfx admin terraform-version disable --versions 1.2.0-beta1,1.2.0-rc1,1.2.0-rc2
 Using config file: /Users/tstraub/.tfx.hcl
 Disable Terraform Versions: [1.2.0-beta1 1.2.0-rc1 1.2.0-rc2]
-1.2.0-beta1: false
-1.2.0-rc1:   false
-1.2.0-rc2:   false
+1.2.0-beta1: Disabled
+1.2.0-rc1:   Disabled
+1.2.0-rc2:   Disabled
 ```
 
 **Error Example**
@@ -178,41 +196,113 @@ Disable Terraform Versions: [1.2.0-beta1 1.2.0-rc1 1.2.0-rc2]
 $ tfx admin terraform-version disable --versions 1.2.0-beta1,1.2.0-rc1,1.2.0-nope
 Using config file: /Users/tstraub/.tfx.hcl
 Disable Terraform Versions: [1.2.0-beta1 1.2.0-rc1 1.2.0-nope]
-1.2.0-beta1: false
-1.2.0-rc1:   false
+1.2.0-beta1: Disabled
+1.2.0-rc1:   Disabled
 1.2.0-nope:  failed to find terraform version
 ```
 
 ## `tfx admin terraform-version disable all`
 
-Disable all Terraform Versions within the Terraform Enterprise install.
-This command will attempt to enable all given versions even if there are failures.
+Disable Terraform Versions within the Terraform Enterprise install. With no filter flags, every version is targeted. Optional filter flags select a subset; only one filter flag may be used per invocation.
+
+This command will attempt to disable all matching versions even if there are failures. Versions currently in use by workspaces cannot be disabled and are reported with `unable to disable a terraform version in use`.
+
+| Flag | Description |
+|---|---|
+| `--except` | Comma-separated keep-list; disable all versions **not** in the list |
+| `--before` | Disable all versions strictly before the given semver (e.g., `1.12.0` disables `1.11.x` and older) |
+| `--not-in-use` | Disable only versions with `Usage == 0` |
+| `--beta` | Disable only versions marked as beta |
+| `--deprecated` | Disable only deprecated versions |
+| `--unofficial` | Disable only unofficial versions |
+| `--official` | Disable only official versions |
 
 :::note
 This command can take up to a minute to run (or longer depending on network latency).
 :::
 
-**Example**
+**Disable all**
 
 ```sh
 $ tfx admin terraform-version disable all
 Using config file: /Users/tstraub/.tfx.hcl
-Disable All Terraform Versions 
-2.0.0:                 false
-1.2.1:                 false
-1.2.0:                 false
-1.2.0-rc2:             false
-1.2.0-rc1:             false
-1.2.0-beta1:           false
-1.1.9:                 false
+Disabling all Terraform versions
+2.0.0:                 Disabled
+1.2.1:                 Disabled
+1.2.0:                 Disabled
+1.1.6:                 unable to disable a terraform version in use
 <redacted for brevity>
-0.6.12:                false
-0.6.11:                false
-0.6.10:                false
-0.6.9:                 false
-0.6.8:                 false
-0.6.7:                 false
-0.6.6:                 false
+```
+
+**Disable all except a keep-list**
+
+```sh
+$ tfx admin terraform-version disable all --except 1.12.0,1.13.0
+Using config file: /Users/tstraub/.tfx.hcl
+Disabling all Terraform versions except: [1.12.0 1.13.0]
+2.0.0: Disabled
+1.2.1: Disabled
+<redacted for brevity>
+1.12.0: (not targeted — kept enabled)
+1.13.0: (not targeted — kept enabled)
+```
+
+**Disable all versions before a semver**
+
+```sh
+$ tfx admin terraform-version disable all --before 1.12.0
+Using config file: /Users/tstraub/.tfx.hcl
+Disabling all Terraform versions before 1.12.0
+1.11.4: Disabled
+1.11.3: Disabled
+1.10.5: Disabled
+<redacted for brevity>
+```
+
+Versions that cannot be parsed as semver (or are equal to or after the cutoff) are skipped.
+
+**Disable unused versions only**
+
+```sh
+$ tfx admin terraform-version disable all --not-in-use
+Using config file: /Users/tstraub/.tfx.hcl
+Disabling unused Terraform versions
+2.0.0: Disabled
+1.2.1: Disabled
+<redacted for brevity>
+```
+
+**Disable beta versions only**
+
+```sh
+$ tfx admin terraform-version disable all --beta
+Using config file: /Users/tstraub/.tfx.hcl
+Disabling beta Terraform versions
+1.6.0-beta1: Disabled
+```
+
+**Disable deprecated versions only**
+
+```sh
+$ tfx admin terraform-version disable all --deprecated
+Using config file: /Users/tstraub/.tfx.hcl
+Disabling deprecated Terraform versions
+```
+
+**Disable unofficial versions only**
+
+```sh
+$ tfx admin terraform-version disable all --unofficial
+Using config file: /Users/tstraub/.tfx.hcl
+Disabling unofficial Terraform versions
+```
+
+**Disable official versions only**
+
+```sh
+$ tfx admin terraform-version disable all --official
+Using config file: /Users/tstraub/.tfx.hcl
+Disabling official Terraform versions
 ```
 
 ## `tfx admin terraform-version enable`
@@ -220,14 +310,16 @@ Disable All Terraform Versions
 Enables a Terraform Version(s), accepts comma separated list.
 This command will attempt to enable all given versions even if there are failures.
 
+Successful enables report `Enabled` in the result output.
+
 **Basic Example**
 
 ```sh
 $ tfx admin terraform-version enable --versions 1.2.0-beta1,1.2.0-rc1,1.2.0-rc2 
 Using config file: /Users/tstraub/.tfx.hcl
 Enable Terraform Versions: [1.2.0-beta1 1.2.0-rc1 1.2.0-rc2]
-1.2.0-beta1: true
-1.2.0-rc1:   true
+1.2.0-beta1: Enabled
+1.2.0-rc1:   Enabled
 ```
 
 **Error Example**
@@ -236,35 +328,85 @@ Enable Terraform Versions: [1.2.0-beta1 1.2.0-rc1 1.2.0-rc2]
 $ tfx admin terraform-version enable --versions 1.2.0-beta1,1.2.0-rc1,1.2.0-nope
 Using config file: /Users/tstraub/.tfx.hcl
 Enable Terraform Versions: [1.2.0-beta1 1.2.0-rc1 1.2.0-nope]
-1.2.0-beta1: true
-1.2.0-rc1:   true
+1.2.0-beta1: Enabled
+1.2.0-rc1:   Enabled
 1.2.0-nope:  failed to find terraform version
 ```
 
 ## `tfx admin terraform-version enable all`
 
-Disable all Terraform Versions within the Terraform Enterprise install.
-This command will attempt to enable all given versions even if there are failures.
+Enable Terraform Versions within the Terraform Enterprise install. With no filter flags, every version is targeted. Optional filter flags select a subset; only one filter flag may be used per invocation.
 
-**Example**
+This command will attempt to enable all matching versions even if there are failures.
+
+| Flag | Description |
+|---|---|
+| `--include` | Comma-separated allow-list; enable only these versions |
+| `--except` | Comma-separated skip-list; enable all versions **not** in the list |
+| `--beta` | Enable only versions marked as beta |
+| `--unofficial` | Enable only unofficial versions |
+| `--official` | Enable only official versions |
+
+:::note
+This command can take up to a minute to run (or longer depending on network latency).
+:::
+
+**Enable all**
 
 ```sh
 $ tfx admin terraform-version enable all
 Using config file: /Users/tstraub/.tfx.hcl
-Enable All Terraform Versions 
-2.0.0:                 true
-1.2.1:                 true
-1.2.0:                 true
-1.2.0-rc2:             true
-1.2.0-rc1:             true
-1.2.0-beta1:           true
-1.1.9:                 true
+Enabling all Terraform versions
+2.0.0:                 Enabled
+1.2.1:                 Enabled
+1.2.0:                 Enabled
 <redacted for brevity>
-0.6.12:                true
-0.6.11:                true
-0.6.10:                true
-0.6.9:                 true
-0.6.8:                 true
-0.6.7:                 true
-0.6.6:                 true
+```
+
+**Enable only specific versions**
+
+```sh
+$ tfx admin terraform-version enable all --include 1.12.0,1.13.0
+Using config file: /Users/tstraub/.tfx.hcl
+Enabling Terraform versions: [1.12.0 1.13.0]
+1.12.0: Enabled
+1.13.0: Enabled
+```
+
+**Enable all except a skip-list**
+
+```sh
+$ tfx admin terraform-version enable all --except 1.12.0,1.13.0
+Using config file: /Users/tstraub/.tfx.hcl
+Enabling all Terraform versions except: [1.12.0 1.13.0]
+2.0.0: Enabled
+1.2.1: Enabled
+<redacted for brevity>
+1.12.0: (not targeted — left disabled)
+1.13.0: (not targeted — left disabled)
+```
+
+**Enable beta versions only**
+
+```sh
+$ tfx admin terraform-version enable all --beta
+Using config file: /Users/tstraub/.tfx.hcl
+Enabling beta Terraform versions
+1.6.0-beta1: Enabled
+```
+
+**Enable unofficial versions only**
+
+```sh
+$ tfx admin terraform-version enable all --unofficial
+Using config file: /Users/tstraub/.tfx.hcl
+Enabling unofficial Terraform versions
+```
+
+**Enable official versions only**
+
+```sh
+$ tfx admin terraform-version enable all --official
+Using config file: /Users/tstraub/.tfx.hcl
+Enabling official Terraform versions
 ```

--- a/site/src/content/docs/testing/test_plan.md
+++ b/site/src/content/docs/testing/test_plan.md
@@ -879,7 +879,30 @@ tfx admin terraform-version disable --versions 1.9.9
 
 **Expected:** Version is now disabled.
 
-### 83. Delete Terraform Version (cleanup)
+### 83. Bulk Enable/Disable Filters
+
+Exercise the bulk filter flags on `disable all` and `enable all`. Pick versions present in your TFE install and adjust the semver values below as needed.
+
+```sh
+# Disable all versions not in a keep-list
+tfx admin terraform-version disable all --except 1.9.0,1.9.9
+
+# Disable versions strictly before a semver cutoff
+tfx admin terraform-version disable all --before 1.9.0
+
+# Disable only unused versions
+tfx admin terraform-version disable all --not-in-use
+
+# Enable only specific versions
+tfx admin terraform-version enable all --include 1.9.0,1.9.9
+
+# Enable all except a skip-list
+tfx admin terraform-version enable all --except 1.9.0
+```
+
+**Expected:** Matching versions report `Disabled` or `Enabled`. Versions in use by workspaces cannot be disabled and report `unable to disable a terraform version in use`. Combining multiple filter flags on one command returns an error.
+
+### 84. Delete Terraform Version (cleanup)
 
 ```sh
 tfx admin terraform-version delete --version 1.9.9
@@ -893,7 +916,7 @@ tfx admin terraform-version delete --version 1.9.9
 
 Use a unique prefix in variable set names (e.g. `tfx-test-<date>`) so cleanup is easy to identify.
 
-### 84. List Variable Sets (organization scope)
+### 85. List Variable Sets (organization scope)
 
 ```sh
 tfx varset list
@@ -901,7 +924,7 @@ tfx varset list
 
 **Expected:** Table of variable sets with `NAME`, `ID`, `GLOBAL`, `PRIORITY`, and `PARENT` columns.
 
-### 85. List Variable Sets (search)
+### 86. List Variable Sets (search)
 
 ```sh
 tfx varset list --search aws
@@ -909,7 +932,7 @@ tfx varset list --search aws
 
 **Expected:** Filtered list matching the search term.
 
-### 86. List Variable Sets (project scope)
+### 87. List Variable Sets (project scope)
 
 ```sh
 tfx varset list --project-name <project-name>
@@ -917,7 +940,7 @@ tfx varset list --project-name <project-name>
 
 **Expected:** Variable sets assigned to the named project.
 
-### 87. Create an Organization-Owned Variable Set
+### 88. Create an Organization-Owned Variable Set
 
 ```sh
 tfx varset create \
@@ -927,7 +950,7 @@ tfx varset create \
 
 **Expected:** Confirmation with variable set ID. Record the name for later steps.
 
-### 88. Show Variable Set by Name
+### 89. Show Variable Set by Name
 
 ```sh
 tfx varset show --name tfx-test-varset
@@ -935,7 +958,7 @@ tfx varset show --name tfx-test-varset
 
 **Expected:** Detail view including parent, workspaces, projects, and variables (empty initially).
 
-### 89. Create a Terraform Variable in the Set
+### 90. Create a Terraform Variable in the Set
 
 ```sh
 tfx varset variable create \
@@ -947,7 +970,7 @@ tfx varset variable create \
 
 **Expected:** Confirmation showing `Category: terraform`.
 
-### 90. Create an Environment Variable in the Set
+### 91. Create an Environment Variable in the Set
 
 ```sh
 tfx varset variable create \
@@ -959,7 +982,7 @@ tfx varset variable create \
 
 **Expected:** Confirmation showing `Category: env`. Keys for environment variables must use letters, numbers, and underscores only (no hyphens).
 
-### 91. List Variables in the Set
+### 92. List Variables in the Set
 
 ```sh
 tfx varset variable list --varset-name tfx-test-varset
@@ -967,7 +990,7 @@ tfx varset variable list --varset-name tfx-test-varset
 
 **Expected:** Table showing both variables created above.
 
-### 92. Show a Variable
+### 93. Show a Variable
 
 ```sh
 tfx varset variable show --varset-name tfx-test-varset --key TFX_TEST_REGION
@@ -975,7 +998,7 @@ tfx varset variable show --varset-name tfx-test-varset --key TFX_TEST_REGION
 
 **Expected:** Detail view for the variable.
 
-### 93. Update a Variable
+### 94. Update a Variable
 
 ```sh
 tfx varset variable update \
@@ -986,7 +1009,7 @@ tfx varset variable update \
 
 **Expected:** Confirmation that the variable was updated.
 
-### 94. Delete Variables (cleanup)
+### 95. Delete Variables (cleanup)
 
 ```sh
 tfx varset variable delete --varset-name tfx-test-varset --key TFX_TEST_REGION
@@ -995,7 +1018,7 @@ tfx varset variable delete --varset-name tfx-test-varset --key TFX_TEST_ENV
 
 **Expected:** Each deletion confirmed with no errors.
 
-### 95. Delete Variable Set (cleanup)
+### 96. Delete Variable Set (cleanup)
 
 ```sh
 tfx varset delete --name tfx-test-varset
@@ -1009,7 +1032,7 @@ tfx varset delete --name tfx-test-varset
 
 These tests verify cross-cutting behavior available on all commands.
 
-### 96. JSON Output Flag (short form)
+### 97. JSON Output Flag (short form)
 
 ```sh
 tfx workspace list -j
@@ -1017,7 +1040,7 @@ tfx workspace list -j
 
 **Expected:** Same JSON output as `--json`.
 
-### 97. Config File Flag
+### 98. Config File Flag
 
 ```sh
 tfx organization list --config-file /path/to/custom/.tfx.hcl
@@ -1025,7 +1048,7 @@ tfx organization list --config-file /path/to/custom/.tfx.hcl
 
 **Expected:** Command runs using the specified config file (confirmation message includes the config path).
 
-### 97a. Config File Env Var
+### 99. Config File Env Var
 
 ```sh
 TFX_CONFIG_FILE=/path/to/custom/.tfx.hcl tfx organization list
@@ -1033,7 +1056,7 @@ TFX_CONFIG_FILE=/path/to/custom/.tfx.hcl tfx organization list
 
 **Expected:** Same result as `--config-file` — config loaded from the env-var path.
 
-### 98. Hostname and Token Flags
+### 100. Hostname and Token Flags
 
 ```sh
 tfx organization list \
@@ -1044,7 +1067,7 @@ tfx organization list \
 
 **Expected:** Same output as using the config file — confirms inline flags override the config.
 
-### 99. Missing Required Flag Error
+### 101. Missing Required Flag Error
 
 ```sh
 tfx workspace show
@@ -1052,7 +1075,7 @@ tfx workspace show
 
 **Expected:** Error message indicating `--name` is required. Exit code is non-zero.
 
-### 100. Invalid Token Error
+### 102. Invalid Token Error
 
 ```sh
 tfx organization list --token invalid-token-value


### PR DESCRIPTION
## Summary
- Add filter flags to `tfx admin terraform-version disable all`: `--except`, `--before`, `--not-in-use`, `--beta`, `--deprecated`, `--official`, `--unofficial`
- Add filter flags to `tfx admin terraform-version enable all`: `--include`, `--except`, `--beta`, `--official`, `--unofficial`
- Bulk enable/disable results now report `Enabled` / `Disabled` instead of raw booleans
- Update CHANGELOG, command docs, README, and test plan

## Test plan
- [ ] `tfx admin terraform-version disable all --not-in-use` disables only unused versions
- [ ] `tfx admin terraform-version disable all --before 1.12.0` disables versions strictly before cutoff
- [ ] `tfx admin terraform-version disable all --except 1.12.0,1.13.0` keeps listed versions enabled
- [ ] `tfx admin terraform-version enable all --include 1.12.0,1.13.0` enables only listed versions
- [ ] `tfx admin terraform-version enable all --except 1.12.0` leaves excepted versions disabled
- [ ] Combining multiple filter flags returns a validation error
- [ ] Successful results show `Enabled` / `Disabled` labels


Made with [Cursor](https://cursor.com)