### PR TITLE
docs: add brew trust step for Homebrew install

### DIFF
--- a/site/src/content/docs/gettingstarted.mdx
+++ b/site/src/content/docs/gettingstarted.mdx
@@ -10,6 +10,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 <Tabs>
   <TabItem label="Homebrew (macOS/Linux)">
 ```sh
+brew trust --formula straubt1/tap/tfx
 brew install straubt1/tap/tfx
 ```
   </TabItem>

--- a/site/src/content/docs/index.mdx
+++ b/site/src/content/docs/index.mdx
@@ -48,6 +48,7 @@ TFx gives you an **interactive TUI** for exploring and a **scriptable CLI** for 
 <Tabs>
   <TabItem label="Homebrew">
 ```sh
+brew trust --formula straubt1/tap/tfx
 brew install straubt1/tap/tfx
 ```
   </TabItem>


### PR DESCRIPTION
## Summary
- Add `brew trust --formula straubt1/tap/tfx` before install on the splash page and Getting Started docs

## Test plan
- [ ] Review rendered Homebrew install tabs on index and getting started pages

Made with [Cursor](https://cursor.com)